### PR TITLE
GATT data caching

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -287,6 +287,17 @@ NobleBindings.prototype.onAclDataPkt = function(handle, cid, data) {
   }
 };
 
+NobleBindings.prototype.addService = function (peripheralUuid, serviceUuid) {
+  var handle = this._handles[peripheralUuid];
+  var gatt = this._gatts[handle];
+
+  if (gatt) {
+    gatt.discoverServices(uuids || []);
+  } else {
+    console.warn('noble warning: unknown peripheral ' + peripheralUuid);
+  }
+
+}
 
 NobleBindings.prototype.discoverServices = function(peripheralUuid, uuids) {
   var handle = this._handles[peripheralUuid];

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -195,8 +195,10 @@ NobleBindings.prototype.onLeConnComplete = function(status, handle, role, addres
 
     this._gatts[handle].on('mtu', this.onMtu.bind(this));
     this._gatts[handle].on('servicesDiscover', this.onServicesDiscovered.bind(this));
+    this._gatts[handle].on('servicesDiscovered', this.onServicesDiscoveredEX.bind(this));
     this._gatts[handle].on('includedServicesDiscover', this.onIncludedServicesDiscovered.bind(this));
     this._gatts[handle].on('characteristicsDiscover', this.onCharacteristicsDiscovered.bind(this));
+    this._gatts[handle].on('characteristicsDiscovered', this.onCharacteristicsDiscoveredEX.bind(this));
     this._gatts[handle].on('read', this.onRead.bind(this));
     this._gatts[handle].on('write', this.onWrite.bind(this));
     this._gatts[handle].on('broadcast', this.onBroadcast.bind(this));
@@ -287,16 +289,15 @@ NobleBindings.prototype.onAclDataPkt = function(handle, cid, data) {
   }
 };
 
-NobleBindings.prototype.addService = function (peripheralUuid, serviceUuid) {
+NobleBindings.prototype.addService = function (peripheralUuid, service) {
   var handle = this._handles[peripheralUuid];
   var gatt = this._gatts[handle];
 
   if (gatt) {
-    gatt.discoverServices(uuids || []);
+    gatt.addService( service );
   } else {
     console.warn('noble warning: unknown peripheral ' + peripheralUuid);
   }
-
 }
 
 NobleBindings.prototype.discoverServices = function(peripheralUuid, uuids) {
@@ -316,6 +317,12 @@ NobleBindings.prototype.onServicesDiscovered = function(address, serviceUuids) {
   this.emit('servicesDiscover', uuid, serviceUuids);
 };
 
+NobleBindings.prototype.onServicesDiscoveredEX = function(address, services) {
+  var uuid = address.split(':').join('').toLowerCase();
+
+  this.emit('servicesDiscovered', uuid, services);
+};
+
 NobleBindings.prototype.discoverIncludedServices = function(peripheralUuid, serviceUuid, serviceUuids) {
   var handle = this._handles[peripheralUuid];
   var gatt = this._gatts[handle];
@@ -331,6 +338,17 @@ NobleBindings.prototype.onIncludedServicesDiscovered = function(address, service
   var uuid = address.split(':').join('').toLowerCase();
 
   this.emit('includedServicesDiscover', uuid, serviceUuid, includedServiceUuids);
+};
+
+NobleBindings.prototype.addCharacteristics = function(peripheralUuid, serviceUuid, characteristics) {
+  var handle = this._handles[peripheralUuid];
+  var gatt = this._gatts[handle];
+
+  if (gatt) {
+    gatt.addCharacteristics(serviceUuid, characteristics);
+  } else {
+    console.warn('noble warning: unknown peripheral ' + peripheralUuid);
+  }
 };
 
 NobleBindings.prototype.discoverCharacteristics = function(peripheralUuid, serviceUuid, characteristicUuids) {
@@ -349,6 +367,13 @@ NobleBindings.prototype.onCharacteristicsDiscovered = function(address, serviceU
 
   this.emit('characteristicsDiscover', uuid, serviceUuid, characteristics);
 };
+
+NobleBindings.prototype.onCharacteristicsDiscoveredEX = function(address, serviceUuid, characteristics) {
+  var uuid = address.split(':').join('').toLowerCase();
+
+  this.emit('characteristicsDiscovered', uuid, serviceUuid, characteristics);
+};
+
 
 NobleBindings.prototype.read = function(peripheralUuid, serviceUuid, characteristicUuid) {
   var handle = this._handles[peripheralUuid];

--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -120,140 +120,145 @@ Gap.prototype.onHciLeAdvertisingReport = function(status, type, address, address
 
   discoveryCount++;
 
-  var i = 0;
-  var j = 0;
-  var serviceUuid = null;
-  var serviceSolicitationUuid = null;
+  try {
 
-  while ((i + 1) < eir.length) {
-    var length = eir.readUInt8(i);
+    var i = 0;
+    var j = 0;
+    var serviceUuid = null;
+    var serviceSolicitationUuid = null;
 
-    if (length < 1) {
-      debug('invalid EIR data, length = ' + length);
-      break;
+    while ((i + 1) < eir.length) {
+      var length = eir.readUInt8(i);
+
+      if (length < 1) {
+        debug('invalid EIR data, length = ' + length);
+        break;
+      }
+
+      var eirType = eir.readUInt8(i + 1); // https://www.bluetooth.org/en-us/specification/assigned-numbers/generic-access-profile
+
+      if ((i + length + 1) > eir.length) {
+        debug('invalid EIR data, out of range of buffer length');
+        break;
+      }
+
+      var bytes = eir.slice(i + 2).slice(0, length - 1);
+
+      switch(eirType) {
+        case 0x02: // Incomplete List of 16-bit Service Class UUID
+        case 0x03: // Complete List of 16-bit Service Class UUIDs
+          for (j = 0; j < bytes.length; j += 2) {
+            serviceUuid = bytes.readUInt16LE(j).toString(16);
+            if (advertisement.serviceUuids.indexOf(serviceUuid) === -1) {
+              advertisement.serviceUuids.push(serviceUuid);
+            }
+          }
+          break;
+
+        case 0x06: // Incomplete List of 128-bit Service Class UUIDs
+        case 0x07: // Complete List of 128-bit Service Class UUIDs
+          for (j = 0; j < bytes.length; j += 16) {
+            serviceUuid = bytes.slice(j, j + 16).toString('hex').match(/.{1,2}/g).reverse().join('');
+            if (advertisement.serviceUuids.indexOf(serviceUuid) === -1) {
+              advertisement.serviceUuids.push(serviceUuid);
+            }
+          }
+          break;
+
+        case 0x08: // Shortened Local Name
+        case 0x09: // Complete Local Name»
+          advertisement.localName = bytes.toString('utf8');
+          break;
+
+        case 0x0a: // Tx Power Level
+          advertisement.txPowerLevel = bytes.readInt8(0);
+          break;
+
+        case  0x14: // List of 16 bit solicitation UUIDs
+          for (j = 0; j < bytes.length; j += 2) {
+            serviceSolicitationUuid = bytes.readUInt16LE(j).toString(16);
+            if (advertisement.serviceSolicitationUuids.indexOf(serviceSolicitationUuid) === -1) {
+              advertisement.serviceSolicitationUuids.push(serviceSolicitationUuid);
+            }
+          }
+          break;
+
+        case  0x15: // List of 128 bit solicitation UUIDs
+          for (j = 0; j < bytes.length; j += 16) {
+            serviceSolicitationUuid = bytes.slice(j, j + 16).toString('hex').match(/.{1,2}/g).reverse().join('');
+            if (advertisement.serviceSolicitationUuids.indexOf(serviceSolicitationUuid) === -1) {
+              advertisement.serviceSolicitationUuids.push(serviceSolicitationUuid);
+            }
+          }
+          break;
+
+        case 0x16: // 16-bit Service Data, there can be multiple occurences
+          var serviceDataUuid = bytes.slice(0, 2).toString('hex').match(/.{1,2}/g).reverse().join('');
+          var serviceData = bytes.slice(2, bytes.length);
+
+          advertisement.serviceData.push({
+            uuid: serviceDataUuid,
+            data: serviceData
+          });
+          break;
+
+        case 0x20: // 32-bit Service Data, there can be multiple occurences
+          var serviceData32Uuid = bytes.slice(0, 4).toString('hex').match(/.{1,2}/g).reverse().join('');
+          var serviceData32 = bytes.slice(4, bytes.length);
+
+          advertisement.serviceData.push({
+            uuid: serviceData32Uuid,
+            data: serviceData32
+          });
+          break;
+
+        case 0x21: // 128-bit Service Data, there can be multiple occurences
+          var serviceData128Uuid = bytes.slice(0, 16).toString('hex').match(/.{1,2}/g).reverse().join('');
+          var serviceData128 = bytes.slice(16, bytes.length);
+
+          advertisement.serviceData.push({
+            uuid: serviceData128Uuid,
+            data: serviceData128
+          });
+          break;
+
+        case  0x1f: // List of 32 bit solicitation UUIDs
+          for (j = 0; j < bytes.length; j += 4) {
+            serviceSolicitationUuid = bytes.readUInt32LE(j).toString(16);
+            if (advertisement.serviceSolicitationUuids.indexOf(serviceSolicitationUuid) === -1) {
+              advertisement.serviceSolicitationUuids.push(serviceSolicitationUuid);
+            }
+          }
+          break;
+
+        case 0xff: // Manufacturer Specific Data
+          advertisement.manufacturerData = bytes;
+          break;
+      }
+
+      i += (length + 1);
     }
 
-    var eirType = eir.readUInt8(i + 1); // https://www.bluetooth.org/en-us/specification/assigned-numbers/generic-access-profile
+    debug('advertisement = ' + JSON.stringify(advertisement, null, 0));
 
-    if ((i + length + 1) > eir.length) {
-      debug('invalid EIR data, out of range of buffer length');
-      break;
+    var connectable = (type === 0x04 && previouslyDiscovered) ? this._discoveries[address].connectable : (type !== 0x03);
+
+    this._discoveries[address] = {
+      address: address,
+      addressType: addressType,
+      connectable: connectable,
+      advertisement: advertisement,
+      rssi: rssi,
+      count: discoveryCount,
+      hasScanResponse: hasScanResponse
+    };
+
+    // only report after a scan response event or if non-connectable or more than one discovery without a scan response, so more data can be collected
+    if (type === 0x04 || !connectable || (discoveryCount > 1 && !hasScanResponse) || process.env.NOBLE_REPORT_ALL_HCI_EVENTS) {
+      this.emit('discover', status, address, addressType, connectable, advertisement, rssi);
     }
-
-    var bytes = eir.slice(i + 2).slice(0, length - 1);
-
-    switch(eirType) {
-      case 0x02: // Incomplete List of 16-bit Service Class UUID
-      case 0x03: // Complete List of 16-bit Service Class UUIDs
-        for (j = 0; j < bytes.length; j += 2) {
-          serviceUuid = bytes.readUInt16LE(j).toString(16);
-          if (advertisement.serviceUuids.indexOf(serviceUuid) === -1) {
-            advertisement.serviceUuids.push(serviceUuid);
-          }
-        }
-        break;
-
-      case 0x06: // Incomplete List of 128-bit Service Class UUIDs
-      case 0x07: // Complete List of 128-bit Service Class UUIDs
-        for (j = 0; j < bytes.length; j += 16) {
-          serviceUuid = bytes.slice(j, j + 16).toString('hex').match(/.{1,2}/g).reverse().join('');
-          if (advertisement.serviceUuids.indexOf(serviceUuid) === -1) {
-            advertisement.serviceUuids.push(serviceUuid);
-          }
-        }
-        break;
-
-      case 0x08: // Shortened Local Name
-      case 0x09: // Complete Local Name»
-        advertisement.localName = bytes.toString('utf8');
-        break;
-
-      case 0x0a: // Tx Power Level
-        advertisement.txPowerLevel = bytes.readInt8(0);
-        break;
-
-      case  0x14: // List of 16 bit solicitation UUIDs
-        for (j = 0; j < bytes.length; j += 2) {
-          serviceSolicitationUuid = bytes.readUInt16LE(j).toString(16);
-          if (advertisement.serviceSolicitationUuids.indexOf(serviceSolicitationUuid) === -1) {
-            advertisement.serviceSolicitationUuids.push(serviceSolicitationUuid);
-          }
-        }
-        break;
-
-      case  0x15: // List of 128 bit solicitation UUIDs
-        for (j = 0; j < bytes.length; j += 16) {
-          serviceSolicitationUuid = bytes.slice(j, j + 16).toString('hex').match(/.{1,2}/g).reverse().join('');
-          if (advertisement.serviceSolicitationUuids.indexOf(serviceSolicitationUuid) === -1) {
-            advertisement.serviceSolicitationUuids.push(serviceSolicitationUuid);
-          }
-        }
-        break;
-
-      case 0x16: // 16-bit Service Data, there can be multiple occurences
-        var serviceDataUuid = bytes.slice(0, 2).toString('hex').match(/.{1,2}/g).reverse().join('');
-        var serviceData = bytes.slice(2, bytes.length);
-
-        advertisement.serviceData.push({
-          uuid: serviceDataUuid,
-          data: serviceData
-        });
-        break;
-
-      case 0x20: // 32-bit Service Data, there can be multiple occurences
-        var serviceData32Uuid = bytes.slice(0, 4).toString('hex').match(/.{1,2}/g).reverse().join('');
-        var serviceData32 = bytes.slice(4, bytes.length);
-
-        advertisement.serviceData.push({
-          uuid: serviceData32Uuid,
-          data: serviceData32
-        });
-        break;
-
-      case 0x21: // 128-bit Service Data, there can be multiple occurences
-        var serviceData128Uuid = bytes.slice(0, 16).toString('hex').match(/.{1,2}/g).reverse().join('');
-        var serviceData128 = bytes.slice(16, bytes.length);
-
-        advertisement.serviceData.push({
-          uuid: serviceData128Uuid,
-          data: serviceData128
-        });
-        break;
-
-      case  0x1f: // List of 32 bit solicitation UUIDs
-        for (j = 0; j < bytes.length; j += 4) {
-          serviceSolicitationUuid = bytes.readUInt32LE(j).toString(16);
-          if (advertisement.serviceSolicitationUuids.indexOf(serviceSolicitationUuid) === -1) {
-            advertisement.serviceSolicitationUuids.push(serviceSolicitationUuid);
-          }
-        }
-        break;
-
-      case 0xff: // Manufacturer Specific Data
-        advertisement.manufacturerData = bytes;
-        break;
-    }
-
-    i += (length + 1);
-  }
-
-  debug('advertisement = ' + JSON.stringify(advertisement, null, 0));
-
-  var connectable = (type === 0x04 && previouslyDiscovered) ? this._discoveries[address].connectable : (type !== 0x03);
-
-  this._discoveries[address] = {
-    address: address,
-    addressType: addressType,
-    connectable: connectable,
-    advertisement: advertisement,
-    rssi: rssi,
-    count: discoveryCount,
-    hasScanResponse: hasScanResponse
-  };
-
-  // only report after a scan response event or if non-connectable or more than one discovery without a scan response, so more data can be collected
-  if (type === 0x04 || !connectable || (discoveryCount > 1 && !hasScanResponse) || process.env.NOBLE_REPORT_ALL_HCI_EVENTS) {
-    this.emit('discover', status, address, addressType, connectable, advertisement, rssi);
+  } catch (e) {
+    debug('GAP: ILLEGAL PACKET! ' + e);
   }
 };
 

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -329,8 +329,11 @@ Gatt.prototype.exchangeMtu = function(mtu) {
   }.bind(this));
 };
 
+Gatt.prototype.addService = function(uuid, serv) {
+}
+
 Gatt.prototype.discoverServices = function(uuids) {
-  var services = [];
+    var services = [];
 
   var callback = function(data) {
     var opcode = data[0];
@@ -359,6 +362,7 @@ Gatt.prototype.discoverServices = function(uuids) {
         this._services[services[i].uuid] = services[i];
       }
       this.emit('servicesDiscover', this._address, serviceUuids);
+      this.emit('servicesDiscovered', this._address, services);
     } else {
       this._queueCommand(this.readByGroupRequest(services[services.length - 1].endHandle + 1, 0xffff, GATT_PRIM_SVC_UUID), callback);
     }

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -329,7 +329,8 @@ Gatt.prototype.exchangeMtu = function(mtu) {
   }.bind(this));
 };
 
-Gatt.prototype.addService = function(uuid, serv) {
+Gatt.prototype.addService = function(service) {
+  this._services[service.uuid] = service;
 }
 
 Gatt.prototype.discoverServices = function(uuids) {
@@ -362,7 +363,7 @@ Gatt.prototype.discoverServices = function(uuids) {
         this._services[services[i].uuid] = services[i];
       }
       this.emit('servicesDiscover', this._address, serviceUuids);
-      this.emit('servicesDiscovered', this._address, services);
+      this.emit('servicesDiscovered', this._address, JSON.parse(JSON.stringify(services)) /*services*/);
     } else {
       this._queueCommand(this.readByGroupRequest(services[services.length - 1].endHandle + 1, 0xffff, GATT_PRIM_SVC_UUID), callback);
     }
@@ -410,6 +411,17 @@ Gatt.prototype.discoverIncludedServices = function(serviceUuid, uuids) {
   this._queueCommand(this.readByTypeRequest(service.startHandle, service.endHandle, GATT_INCLUDE_UUID), callback);
 };
 
+Gatt.prototype.addCharacteristics = function(serviceUuid, characteristics) {
+  var service = this._services[serviceUuid];
+  this._characteristics[serviceUuid] = this._characteristics[serviceUuid] || {};
+  this._descriptors[serviceUuid] = this._descriptors[serviceUuid] || {};
+
+
+  for (i = 0; i < characteristics.length; i++) {
+    this._characteristics[serviceUuid][characteristics[i].uuid] = characteristics[i];
+  }
+}
+
 Gatt.prototype.discoverCharacteristics = function(serviceUuid, characteristicUuids) {
   var service = this._services[serviceUuid];
   var characteristics = [];
@@ -445,7 +457,9 @@ Gatt.prototype.discoverCharacteristics = function(serviceUuid, characteristicUui
           properties: [],
           uuid: characteristics[i].uuid
         };
-
+        characteristics[i].propsDecoded = characteristic.properties
+        characteristics[i].rawProps = properties
+        
         if (i !== 0) {
           characteristics[i - 1].endHandle = characteristics[i].startHandle - 1;
         }
@@ -494,6 +508,7 @@ Gatt.prototype.discoverCharacteristics = function(serviceUuid, characteristicUui
       }
 
       this.emit('characteristicsDiscover', this._address, serviceUuid, characteristicsDiscovered);
+      this.emit('characteristicsDiscovered', this._address, serviceUuid, characteristics);
     } else {
       this._queueCommand(this.readByTypeRequest(characteristics[characteristics.length - 1].valueHandle + 1, service.endHandle, GATT_CHARAC_UUID), callback);
     }
@@ -689,6 +704,7 @@ Gatt.prototype.discoverDescriptors = function(serviceUuid, characteristicUuid) {
       }
 
       this.emit('descriptorsDiscover', this._address, serviceUuid, characteristicUuid, descriptorUuids);
+      this.emit('descriptorsDiscovered', this._address, serviceUuid, characteristicUuid, descriptors);
     } else {
       this._queueCommand(this.findInfoRequest(descriptors[descriptors.length - 1].handle + 1, characteristic.endHandle), callback);
     }

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -110,6 +110,12 @@ Hci.prototype.pollIsDevUp = function() {
 
   if (this._isDevUp !== isDevUp) {
     if (isDevUp) {
+      if (this._state === 'poweredOff') {
+        this._socket.removeAllListeners();
+        this._state = null;
+        this.init();
+        return;
+      }
       this.setSocketFilter();
       this.setEventMask();
       this.setLeEventMask();

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -270,8 +270,8 @@ Hci.prototype.setScanParameters = function() {
 
   // data
   cmd.writeUInt8(0x01, 4); // type: 0 -> passive, 1 -> active
-  cmd.writeUInt16LE(0x03C0, 5); // internal, ms * 1.6
-  cmd.writeUInt16LE(0x03C0, 7); // window, ms * 1.6
+  cmd.writeUInt16LE(0x0060, 5); // internal, ms * 1.6
+  cmd.writeUInt16LE(0x0030, 7); // window, ms * 1.6
   cmd.writeUInt8(0x00, 9); // own address type: 0 -> public, 1 -> random
   cmd.writeUInt8(0x00, 10); // filter: 0 -> all event types
 
@@ -308,8 +308,8 @@ Hci.prototype.createLeConn = function(address, addressType) {
   cmd.writeUInt8(0x19, 3);
 
   // data
-  cmd.writeUInt16LE(0x0100, 4); // interval
-  cmd.writeUInt16LE(0x00A0, 6); // window
+  cmd.writeUInt16LE(0x0060, 4); // interval
+  cmd.writeUInt16LE(0x0030, 6); // window
   cmd.writeUInt8(0x00, 8); // initiator filter
 
   cmd.writeUInt8(addressType === 'random' ? 0x01 : 0x00, 9); // peer address type
@@ -317,8 +317,8 @@ Hci.prototype.createLeConn = function(address, addressType) {
 
   cmd.writeUInt8(0x00, 16); // own address type
 
-  cmd.writeUInt16LE(0x000c, 17); // min interval
-  cmd.writeUInt16LE(0x0018, 19); // max interval
+  cmd.writeUInt16LE(0x0006, 17); // min interval
+  cmd.writeUInt16LE(0x000c, 19); // max interval
   cmd.writeUInt16LE(0x0000, 21); // latency
   cmd.writeUInt16LE(0x00c8, 23); // supervision timeout
   cmd.writeUInt16LE(0x0004, 25); // min ce length

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -270,8 +270,8 @@ Hci.prototype.setScanParameters = function() {
 
   // data
   cmd.writeUInt8(0x01, 4); // type: 0 -> passive, 1 -> active
-  cmd.writeUInt16LE(0x0010, 5); // internal, ms * 1.6
-  cmd.writeUInt16LE(0x0010, 7); // window, ms * 1.6
+  cmd.writeUInt16LE(0x03C0, 5); // internal, ms * 1.6
+  cmd.writeUInt16LE(0x03C0, 7); // window, ms * 1.6
   cmd.writeUInt8(0x00, 9); // own address type: 0 -> public, 1 -> random
   cmd.writeUInt8(0x00, 10); // filter: 0 -> all event types
 
@@ -308,8 +308,8 @@ Hci.prototype.createLeConn = function(address, addressType) {
   cmd.writeUInt8(0x19, 3);
 
   // data
-  cmd.writeUInt16LE(0x0060, 4); // interval
-  cmd.writeUInt16LE(0x0030, 6); // window
+  cmd.writeUInt16LE(0x0100, 4); // interval
+  cmd.writeUInt16LE(0x00A0, 6); // window
   cmd.writeUInt8(0x00, 8); // initiator filter
 
   cmd.writeUInt8(addressType === 'random' ? 0x01 : 0x00, 9); // peer address type
@@ -317,8 +317,8 @@ Hci.prototype.createLeConn = function(address, addressType) {
 
   cmd.writeUInt8(0x00, 16); // own address type
 
-  cmd.writeUInt16LE(0x0006, 17); // min interval
-  cmd.writeUInt16LE(0x000c, 19); // max interval
+  cmd.writeUInt16LE(0x000c, 17); // min interval
+  cmd.writeUInt16LE(0x0018, 19); // max interval
   cmd.writeUInt16LE(0x0000, 21); // latency
   cmd.writeUInt16LE(0x00c8, 23); // supervision timeout
   cmd.writeUInt16LE(0x0004, 25); // min ce length

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -640,23 +640,27 @@ Hci.prototype.processLeConnComplete = function(status, data) {
 };
 
 Hci.prototype.processLeAdvertisingReport = function(count, data) {
-  for (var i = 0; i < count; i++) {
-    var type = data.readUInt8(0);
-    var addressType = data.readUInt8(1) === 0x01 ? 'random' : 'public';
-    var address = data.slice(2, 8).toString('hex').match(/.{1,2}/g).reverse().join(':');
-    var eirLength = data.readUInt8(8);
-    var eir = data.slice(9, eirLength + 9);
-    var rssi = data.readInt8(eirLength + 9);
+  try {
+    for (var i = 0; i < count; i++) {
+      var type = data.readUInt8(0);
+      var addressType = data.readUInt8(1) === 0x01 ? 'random' : 'public';
+      var address = data.slice(2, 8).toString('hex').match(/.{1,2}/g).reverse().join(':');
+      var eirLength = data.readUInt8(8);
+      var eir = data.slice(9, eirLength + 9);
+      var rssi = data.readInt8(eirLength + 9);
 
-    debug('\t\t\ttype = ' + type);
-    debug('\t\t\taddress = ' + address);
-    debug('\t\t\taddress type = ' + addressType);
-    debug('\t\t\teir = ' + eir.toString('hex'));
-    debug('\t\t\trssi = ' + rssi);
+      debug('\t\t\ttype = ' + type);
+      debug('\t\t\taddress = ' + address);
+      debug('\t\t\taddress type = ' + addressType);
+      debug('\t\t\teir = ' + eir.toString('hex'));
+      debug('\t\t\trssi = ' + rssi);
 
-    this.emit('leAdvertisingReport', 0, type, address, addressType, eir, rssi);
+      this.emit('leAdvertisingReport', 0, type, address, addressType, eir, rssi);
 
-    data = data.slice(eirLength + 10);
+      data = data.slice(eirLength + 10);
+    }
+  } catch (e) {
+    debug('CAUGHT EXCEPTION - ILLEGAL PACKET ' + e);
   }
 };
 

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -29,6 +29,7 @@ function Noble(bindings) {
   this._bindings.on('disconnect', this.onDisconnect.bind(this));
   this._bindings.on('rssiUpdate', this.onRssiUpdate.bind(this));
   this._bindings.on('servicesDiscover', this.onServicesDiscover.bind(this));
+  this._bindings.on('servicesDiscovered', this.onServicesDiscovered.bind(this));
   this._bindings.on('includedServicesDiscover', this.onIncludedServicesDiscover.bind(this));
   this._bindings.on('characteristicsDiscover', this.onCharacteristicsDiscover.bind(this));
   this._bindings.on('read', this.onRead.bind(this));
@@ -225,9 +226,42 @@ Noble.prototype.onRssiUpdate = function(peripheralUuid, rssi) {
   }
 };
 
+/// service is a ServiceObject { uuid, startHandle, endHandle,..}
+Noble.prototype.addService = function (peripheralUuid, service) {
+  var peripheral = this._peripherals[peripheralUuid];
+
+  // pass on to lower layers (gatt)
+  this._bindings.addService(peripheralUuid, service);
+
+  console.log('onSD ' + peripheralUuid + ' ' + serviceUuid)
+
+  if (!peripheral.services) {
+    peripheral.services = []
+  }
+
+  var service = new Service(this, peripheralUuid, serviceUuid);
+  console.log('onSD 2 ' + peripheralUuid + ' ' + service)
+
+  this._services[peripheralUuid][serviceUuid] = service;
+  this._characteristics[peripheralUuid][serviceUuid] = {};
+  this._descriptors[peripheralUuid][serviceUuid] = {};
+
+  peripheral.services.push(service);
+
+  return service;
+}
+
 Noble.prototype.discoverServices = function(peripheralUuid, uuids) {
   this._bindings.discoverServices(peripheralUuid, uuids);
 };
+
+/// callback receiving a list of service objects from the gatt layer
+Noble.prototype.onServicesDiscovered = function(peripheralUuid, servics) {
+  var peripheral = this._peripherals[peripheralUuid];
+
+  peripheral.emit('servicesDiscovered', services); // pass on to higher layers
+}
+
 
 Noble.prototype.onServicesDiscover = function(peripheralUuid, serviceUuids) {
   var peripheral = this._peripherals[peripheralUuid];

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -226,6 +226,16 @@ Noble.prototype.onRssiUpdate = function(peripheralUuid, rssi) {
   }
 };
 
+Noble.prototype.addServices = function (peripheralUuid, services) {
+  let servObjs = [];
+
+  for (let i = 0 ; i< services.length ; i++) {
+    let o = this.addService(peripheralUuid, services[i])
+    servObjs.push(o)
+  }
+  return servObjs;
+}
+
 /// service is a ServiceObject { uuid, startHandle, endHandle,..}
 Noble.prototype.addService = function (peripheralUuid, service) {
   var peripheral = this._peripherals[peripheralUuid];
@@ -233,22 +243,19 @@ Noble.prototype.addService = function (peripheralUuid, service) {
   // pass on to lower layers (gatt)
   this._bindings.addService(peripheralUuid, service);
 
-  console.log('onSD ' + peripheralUuid + ' ' + serviceUuid)
-
   if (!peripheral.services) {
     peripheral.services = []
   }
+  // allocate internal service object and return
+  var serv = new Service(this, peripheralUuid, service.uuid);
 
-  var service = new Service(this, peripheralUuid, serviceUuid);
-  console.log('onSD 2 ' + peripheralUuid + ' ' + service)
+  this._services[peripheralUuid][service.uuid] = serv;
+  this._characteristics[peripheralUuid][service.uuid] = {};
+  this._descriptors[peripheralUuid][service.uuid] = {};
 
-  this._services[peripheralUuid][serviceUuid] = service;
-  this._characteristics[peripheralUuid][serviceUuid] = {};
-  this._descriptors[peripheralUuid][serviceUuid] = {};
+  peripheral.services.push(serv);
 
-  peripheral.services.push(service);
-
-  return service;
+  return serv;
 }
 
 Noble.prototype.discoverServices = function(peripheralUuid, uuids) {
@@ -256,10 +263,15 @@ Noble.prototype.discoverServices = function(peripheralUuid, uuids) {
 };
 
 /// callback receiving a list of service objects from the gatt layer
-Noble.prototype.onServicesDiscovered = function(peripheralUuid, servics) {
+Noble.prototype.onServicesDiscovered = function(peripheralUuid, services) {
+  console.log('Noble.prototype.onServicesDiscovered ' + peripheralUuid);
+
   var peripheral = this._peripherals[peripheralUuid];
 
-  peripheral.emit('servicesDiscovered', services); // pass on to higher layers
+  console.log('Noble.prototype.onServicesDiscovered ' + peripheral);
+
+  if (peripheral)
+    peripheral.emit('servicesDiscovered', peripheral, services); // pass on to higher layers
 }
 
 
@@ -303,6 +315,39 @@ Noble.prototype.onIncludedServicesDiscover = function(peripheralUuid, serviceUui
     this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ' included services discover!');
   }
 };
+
+Noble.prototype.addCharacteristics = function(peripheralUuid, serviceUuid, characteristics) {
+  this._bindings.addCharacteristics(peripheralUuid, serviceUuid, characteristics);
+
+  var service = this._services[peripheralUuid][serviceUuid];
+  if (!service ) {
+    this.emit('warning', 'unknown peripheral ' + peripheralUuid + ', ' + serviceUuid + ' characteristics discover!');
+    return
+  }
+
+  let characteristics_ = [];
+  for (var i = 0; i < characteristics.length; i++) {
+    var characteristicUuid = characteristics[i].uuid;
+
+    var characteristic = new Characteristic(
+                              this,
+                              peripheralUuid,
+                              serviceUuid,
+                              characteristicUuid,
+                              characteristics[i].properties
+                          );
+
+    this._characteristics[peripheralUuid][serviceUuid][characteristicUuid] = characteristic;
+    this._descriptors[peripheralUuid][serviceUuid][characteristicUuid] = {};
+
+    characteristics_.push(characteristic);
+  }
+
+  service.characteristics = characteristics_;
+
+  return characteristics_;
+};
+
 
 Noble.prototype.discoverCharacteristics = function(peripheralUuid, serviceUuid, characteristicUuids) {
   this._bindings.discoverCharacteristics(peripheralUuid, serviceUuid, characteristicUuids);


### PR DESCRIPTION
We have a number of known BLE devices the we (re-)connect to often. Speeding up the connection setup phase is good for the user experience (less delay, less potential for packet loss), so we have extended noble a little to report the GATT data structures for services and characteristics.
In order to not change default behavour, there are two new events one can listen for when discovering GATT entries, simply register them before the actual discovery call:
``` 
 peripheral.on('servicesDiscovered', (peripheral, services) => { ... }
 service.on('characteristicsDiscovered', (characteristics) => {...}
```
returns an array of services resp. characteristics including low-level information that can be used to initialize noble:

 
```
 const servs = [
        { "startHandle": 1, "endHandle": 4, "uuid": "1801" },
        { "startHandle": 5, "endHandle": 9, "uuid": "1800" },
        { "startHandle": 10, "endHandle": 29, "uuid": "180a" }]
 let serviceObjs =  noble.addServices(peripheralUuid, servs)

 const enviroChara = [
  { "startHandle": 53, "properties": 18, "valueHandle": 54, "uuid": "2a6d", "propsDecoded": ["read", "notify"], "rawProps": 18, "endHandle": 57 },
  { "startHandle": 58, "properties": 18, "valueHandle": 59, "uuid": "2a6e", "propsDecoded": ["read", "notify"], "rawProps": 18, "endHandle": 62 }]

 let characteristicsObjs = noble.addCharacteristics(peripheral.uuid, enviroService.uuid, enviroChara);
```
 
addServices returns an array of service objects, addCharacteristics an array of Characteristic objects that  can be used to discover, subscribe for data etc.




  