### PR TITLE
Safeguard LE Advertising report processing

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -634,23 +634,27 @@ Hci.prototype.processLeConnComplete = function(status, data) {
 };
 
 Hci.prototype.processLeAdvertisingReport = function(count, data) {
-  for (var i = 0; i < count; i++) {
-    var type = data.readUInt8(0);
-    var addressType = data.readUInt8(1) === 0x01 ? 'random' : 'public';
-    var address = data.slice(2, 8).toString('hex').match(/.{1,2}/g).reverse().join(':');
-    var eirLength = data.readUInt8(8);
-    var eir = data.slice(9, eirLength + 9);
-    var rssi = data.readInt8(eirLength + 9);
+  try {
+    for (var i = 0; i < count; i++) {
+      var type = data.readUInt8(0);
+      var addressType = data.readUInt8(1) === 0x01 ? 'random' : 'public';
+      var address = data.slice(2, 8).toString('hex').match(/.{1,2}/g).reverse().join(':');
+      var eirLength = data.readUInt8(8);
+      var eir = data.slice(9, eirLength + 9);
+      var rssi = data.readInt8(eirLength + 9);
 
-    debug('\t\t\ttype = ' + type);
-    debug('\t\t\taddress = ' + address);
-    debug('\t\t\taddress type = ' + addressType);
-    debug('\t\t\teir = ' + eir.toString('hex'));
-    debug('\t\t\trssi = ' + rssi);
+      debug('\t\t\ttype = ' + type);
+      debug('\t\t\taddress = ' + address);
+      debug('\t\t\taddress type = ' + addressType);
+      debug('\t\t\teir = ' + eir.toString('hex'));
+      debug('\t\t\trssi = ' + rssi);
 
-    this.emit('leAdvertisingReport', 0, type, address, addressType, eir, rssi);
+      this.emit('leAdvertisingReport', 0, type, address, addressType, eir, rssi);
 
-    data = data.slice(eirLength + 10);
+      data = data.slice(eirLength + 10);
+    }
+  } catch (e) {
+    console.warn('processLeAdvertisingReport: Caught illegal packet (buffer overflow): ' + e);
   }
 };
 


### PR DESCRIPTION
add try/catch around region affected by buffer overflow if eirLength fields are corrupted. This happens on some firmwares that send out multiple advertisements but do not fix the length fields (which eventually causes kernel panics as well).