### PR TITLE
Support Promises

### DIFF
--- a/examples/peripheral-explorer-async.js
+++ b/examples/peripheral-explorer-async.js
@@ -1,0 +1,110 @@
+const noble = require('../');
+
+const peripheralIdOrAddress = process.argv[2].toLowerCase();
+
+noble.on('stateChange', async (state) => {
+  if (state === 'poweredOn') {
+    await noble.startScanningAsync([], false);
+  }
+});
+
+noble.on('discover', async (peripheral) => {
+  if ([peripheral.id, peripheral.address].includes(peripheralIdOrAddress)) {
+    await noble.stopScanningAsync();
+
+    console.log(`Peripheral with ID ${peripheral.id} found`);
+    const advertisement = peripheral.advertisement;
+
+    const localName = advertisement.localName;
+    const txPowerLevel = advertisement.txPowerLevel;
+    const manufacturerData = advertisement.manufacturerData;
+    const serviceData = advertisement.serviceData;
+    const serviceUuids = advertisement.serviceUuids;
+
+    if (localName) {
+      console.log(`  Local Name        = ${localName}`);
+    }
+
+    if (txPowerLevel) {
+      console.log(`  TX Power Level    = ${txPowerLevel}`);
+    }
+
+    if (manufacturerData) {
+      console.log(`  Manufacturer Data = ${manufacturerData.toString('hex')}`);
+    }
+
+    if (serviceData) {
+      console.log(`  Service Data      = ${JSON.stringify(serviceData, null, 2)}`);
+    }
+
+    if (serviceUuids) {
+      console.log(`  Service UUIDs     = ${serviceUuids}`);
+    }
+
+    console.log();
+
+    await explore(peripheral);
+  }
+});
+
+/**
+ * @param {import('../').Peripheral} peripheral
+ */
+const explore = async (peripheral) => {
+  console.log('Services and characteristics:');
+
+  peripheral.on('disconnect', () => {
+    process.exit(0);
+  });
+
+  await peripheral.connectAsync();
+
+  const services = await peripheral.discoverServicesAsync([]);
+
+  for (const service of services) {
+    let serviceInfo = service.uuid;
+
+    if (service.name) {
+      serviceInfo += ` (${service.name})`;
+    }
+
+    console.log(serviceInfo);
+
+    const characteristics = await service.discoverCharacteristicsAsync([]);
+
+    for (const characteristic of characteristics) {
+      let characteristicInfo = `  ${characteristic.uuid}`;
+
+      if (characteristic.name) {
+        characteristicInfo += ` (${characteristic.name})`;
+      }
+
+      const descriptors = await characteristic.discoverDescriptorsAsync();
+
+      const userDescriptionDescriptor = descriptors.find((descriptor) => descriptor.uuid === '2901');
+
+      if (userDescriptionDescriptor) {
+        const data = await userDescriptionDescriptor.readValueAsync();
+        if (data) {
+          characteristicInfo += ` (${data.toString()})`;
+        }
+      }
+
+      characteristicInfo += `\n    properties  ${characteristic.properties.join(', ')}`;
+
+      if (characteristic.properties.includes('read')) {
+        const data = await characteristic.readAsync();
+
+        if (data) {
+          const string = data.toString('ascii');
+
+          characteristicInfo += `\n    value       ${data.toString('hex')} | '${string}'`;
+        }
+      }
+
+      console.log(characteristicInfo);
+    }
+  }
+
+  await peripheral.disconnectAsync();
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,9 +14,13 @@
 import events = require("events");
 
 export declare function startScanning(callback?: (error?: Error) => void): void;
+export declare function startScanningAsync(): Promise<void>;
 export declare function startScanning(serviceUUIDs: string[], callback?: (error?: Error) => void): void;
+export declare function startScanningAsync(serviceUUIDs: string[]): Promise<void>;
 export declare function startScanning(serviceUUIDs: string[], allowDuplicates: boolean, callback?: (error?: Error) => void): void;
+export declare function startScanningAsync(serviceUUIDs: string[], allowDuplicates: boolean): Promise<void>;
 export declare function stopScanning(callback?: () => void): void;
+export declare function stopScanningAsync(): Promise<void>;
 
 export declare function on(event: "stateChange", listener: (state: string) => void): events.EventEmitter;
 export declare function on(event: "scanStart", listener: () => void): events.EventEmitter;
@@ -34,6 +38,11 @@ export declare function removeAllListeners(event?: string): events.EventEmitter;
 
 export declare var state: string;
 
+export interface ServicesAndCharacteristics {
+  services: Service[];
+  characteristics: Characteristic[];
+};
+
 export declare class Peripheral extends events.EventEmitter {
     id: string;
     uuid: string;
@@ -46,14 +55,22 @@ export declare class Peripheral extends events.EventEmitter {
     state: 'error' | 'connecting' | 'connected' | 'disconnecting' | 'disconnected';
 
     connect(callback?: (error: string) => void): void;
+    connectAsync(): Promise<void>;
     disconnect(callback?: () => void): void;
+    disconnectAsync(): Promise<void>;
     updateRssi(callback?: (error: string, rssi: number) => void): void;
+    updateRssiAsync(): Promise<number>;
     discoverServices(serviceUUIDs: string[], callback?: (error: string, services: Service[]) => void): void;
+    discoverServicesAsync(serviceUUIDs: string[]): Promise<Service[]>;
     discoverAllServicesAndCharacteristics(callback?: (error: string, services: Service[], characteristics: Characteristic[]) => void): void;
+    discoverAllServicesAndCharacteristicsAsync(): Promise<ServicesAndCharacteristics>;
     discoverSomeServicesAndCharacteristics(serviceUUIDs: string[], characteristicUUIDs: string[], callback?: (error: string, services: Service[], characteristics: Characteristic[]) => void): void;
+    discoverSomeServicesAndCharacteristicsAsync(serviceUUIDs: string[], characteristicUUIDs: string[]): Promise<ServicesAndCharacteristics>;
 
     readHandle(handle: Buffer, callback: (error: string, data: Buffer) => void): void;
+    readHandleAsync(handle: Buffer): Promise<Buffer>;
     writeHandle(handle: Buffer, data: Buffer, withoutResponse: boolean, callback: (error: string) => void): void;
+    writeHandleAsync(handle: Buffer, data: Buffer, withoutResponse: boolean): Promise<void>;
     toString(): string;
 
     on(event: "connect", listener: (error: string) => void): this;
@@ -82,7 +99,9 @@ export declare class Service extends events.EventEmitter {
     characteristics: Characteristic[];
 
     discoverIncludedServices(serviceUUIDs: string[], callback?: (error: string, includedServiceUuids: string[]) => void): void;
+    discoverIncludedServicesAsync(serviceUUIDs: string[]): Promise<string[]>;
     discoverCharacteristics(characteristicUUIDs: string[], callback?: (error: string, characteristics: Characteristic[]) => void): void;
+    discoverCharacteristicsAsync(characteristicUUIDs: string[]): Promise<Characteristic[]>;
     toString(): string;
 
     on(event: "includedServicesDiscover", listener: (includedServiceUuids: string[]) => void): this;
@@ -98,13 +117,20 @@ export declare class Characteristic extends events.EventEmitter {
     descriptors: Descriptor[];
 
     read(callback?: (error: string, data: Buffer) => void): void;
+    readAsync(): Promise<Buffer>;
     write(data: Buffer, notify: boolean, callback?: (error: string) => void): void;
+    writeAsync(data: Buffer, notify: boolean): Promise<void>;
     broadcast(broadcast: boolean, callback?: (error: string) => void): void;
+    broadcastAsync(broadcast: boolean): Promise<void>;
     notify(notify: boolean, callback?: (error: string) => void): void;
+    notifyAsync(notify: boolean): Promise<void>;
     discoverDescriptors(callback?: (error: string, descriptors: Descriptor[]) => void): void;
+    discoverDescriptorsAsync(): Promise<Descriptor[]>;
     toString(): string;
     subscribe(callback?: (error: string) => void): void;
+    subscribeAsync(): Promise<void>;
     unsubscribe(callback?: (error: string) => void): void;
+    unsubscribeAsync(): Promise<void>;
 
     on(event: "read", listener: (data: Buffer, isNotification: boolean) => void): this;
     on(event: "write", withoutResponse: boolean, listener: (error: string) => void): this;
@@ -121,7 +147,9 @@ export declare class Descriptor extends events.EventEmitter {
     type: string;
 
     readValue(callback?: (error: string, data: Buffer) => void): void;
+    readValueAsync(): Promise<Buffer>;
     writeValue(data: Buffer, callback?: (error: string) => void): void;
+    writeValueAsync(data: Buffer): Promise<void>;
     toString(): string;
 
     on(event: "valueRead", listener: (error: string, data: Buffer) => void): this;

--- a/lib/characteristic.js
+++ b/lib/characteristic.js
@@ -32,7 +32,7 @@ Characteristic.prototype.toString = function () {
   });
 };
 
-Characteristic.prototype.read = function (callback) {
+const read = function (callback) {
   if (callback) {
     const onRead = (data, isNotification) => {
       // only call the callback if 'read' event and non-notification
@@ -56,7 +56,10 @@ Characteristic.prototype.read = function (callback) {
   );
 };
 
-Characteristic.prototype.write = function (data, withoutResponse, callback) {
+Characteristic.prototype.read = read;
+Characteristic.prototype.readAsync = util.promisify(read);
+
+const write = function (data, withoutResponse, callback) {
   if (process.title !== 'browser') {
     if (!(data instanceof Buffer)) {
       throw new Error('data must be a Buffer');
@@ -78,7 +81,10 @@ Characteristic.prototype.write = function (data, withoutResponse, callback) {
   );
 };
 
-Characteristic.prototype.broadcast = function (broadcast, callback) {
+Characteristic.prototype.write = write;
+Characteristic.prototype.writeAsync = util.promisify(write);
+
+const broadcast = function (broadcast, callback) {
   if (callback) {
     this.once('broadcast', () => {
       callback(null);
@@ -93,8 +99,11 @@ Characteristic.prototype.broadcast = function (broadcast, callback) {
   );
 };
 
+Characteristic.prototype.broadcast = broadcast;
+Characteristic.prototype.broadcastAsync = util.promisify(broadcast);
+
 // deprecated in favour of subscribe/unsubscribe
-Characteristic.prototype.notify = function (notify, callback) {
+const notify = function (notify, callback) {
   if (callback) {
     this.once('notify', () => {
       callback(null);
@@ -109,15 +118,24 @@ Characteristic.prototype.notify = function (notify, callback) {
   );
 };
 
-Characteristic.prototype.subscribe = function (callback) {
+Characteristic.prototype.notify = notify;
+Characteristic.prototype.notifyAsync = util.promisify(notify);
+
+const subscribe = function (callback) {
   this.notify(true, callback);
 };
 
-Characteristic.prototype.unsubscribe = function (callback) {
+Characteristic.prototype.subscribe = subscribe;
+Characteristic.prototype.subscribeAsync = util.promisify(subscribe);
+
+const unsubscribe = function (callback) {
   this.notify(false, callback);
 };
 
-Characteristic.prototype.discoverDescriptors = function (callback) {
+Characteristic.prototype.unsubscribe = unsubscribe;
+Characteristic.prototype.unsubscribeAsync = util.promisify(unsubscribe);
+
+const discoverDescriptors = function (callback) {
   if (callback) {
     this.once('descriptorsDiscover', descriptors => {
       callback(null, descriptors);
@@ -130,5 +148,8 @@ Characteristic.prototype.discoverDescriptors = function (callback) {
     this.uuid
   );
 };
+
+Characteristic.prototype.discoverDescriptors = discoverDescriptors;
+Characteristic.prototype.discoverDescriptorsAsync = util.promisify(discoverDescriptors);
 
 module.exports = Characteristic;

--- a/lib/descriptor.js
+++ b/lib/descriptor.js
@@ -30,7 +30,7 @@ Descriptor.prototype.toString = function () {
   });
 };
 
-Descriptor.prototype.readValue = function (callback) {
+const readValue = function (callback) {
   if (callback) {
     this.once('valueRead', data => {
       callback(null, data);
@@ -44,7 +44,10 @@ Descriptor.prototype.readValue = function (callback) {
   );
 };
 
-Descriptor.prototype.writeValue = function (data, callback) {
+Descriptor.prototype.readValue = readValue;
+Descriptor.prototype.readValueAsync = util.promisify(readValue);
+
+const writeValue = function (data, callback) {
   if (!(data instanceof Buffer)) {
     throw new Error('data must be a Buffer');
   }
@@ -62,5 +65,8 @@ Descriptor.prototype.writeValue = function (data, callback) {
     data
   );
 };
+
+Descriptor.prototype.writeValue = writeValue;
+Descriptor.prototype.writeValueAsync = util.promisify(writeValue);
 
 module.exports = Descriptor;

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -93,7 +93,7 @@ Noble.prototype.onAddressChange = function (address) {
   this.address = address;
 };
 
-Noble.prototype.startScanning = function (serviceUuids, allowDuplicates, callback) {
+const startScanning = function (serviceUuids, allowDuplicates, callback) {
   const scan = function (state) {
     if (state !== 'poweredOn') {
       const error = new Error(`Could not start scanning, state is ${state} (not poweredOn)`);
@@ -129,12 +129,15 @@ Noble.prototype.startScanning = function (serviceUuids, allowDuplicates, callbac
   }
 };
 
+Noble.prototype.startScanning = startScanning;
+Noble.prototype.startScanningAsync = util.promisify(startScanning);
+
 Noble.prototype.onScanStart = function (filterDuplicates) {
   debug('scanStart');
   this.emit('scanStart', filterDuplicates);
 };
 
-Noble.prototype.stopScanning = function (callback) {
+const stopScanning = function (callback) {
   if (callback) {
     this.once('scanStop', callback);
   }
@@ -142,6 +145,9 @@ Noble.prototype.stopScanning = function (callback) {
     this._bindings.stopScanning();
   }
 };
+
+Noble.prototype.stopScanning = stopScanning;
+Noble.prototype.stopScanningAsync = util.promisify(stopScanning);
 
 Noble.prototype.onScanStop = function () {
   debug('scanStop');

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -31,7 +31,7 @@ Peripheral.prototype.toString = function () {
   });
 };
 
-Peripheral.prototype.connect = function (callback) {
+const connect = function (callback) {
   if (callback) {
     this.once('connect', error => {
       callback(error);
@@ -46,7 +46,10 @@ Peripheral.prototype.connect = function (callback) {
   }
 };
 
-Peripheral.prototype.disconnect = function (callback) {
+Peripheral.prototype.connect = connect;
+Peripheral.prototype.connectAsync = util.promisify(connect);
+
+const disconnect = function (callback) {
   if (callback) {
     this.once('disconnect', () => {
       callback(null);
@@ -56,7 +59,10 @@ Peripheral.prototype.disconnect = function (callback) {
   this._noble.disconnect(this.id);
 };
 
-Peripheral.prototype.updateRssi = function (callback) {
+Peripheral.prototype.disconnect = disconnect;
+Peripheral.prototype.disconnectAsync = util.promisify(disconnect);
+
+const updateRssi = function (callback) {
   if (callback) {
     this.once('rssiUpdate', rssi => {
       callback(null, rssi);
@@ -66,7 +72,10 @@ Peripheral.prototype.updateRssi = function (callback) {
   this._noble.updateRssi(this.id);
 };
 
-Peripheral.prototype.discoverServices = function (uuids, callback) {
+Peripheral.prototype.updateRssi = updateRssi;
+Peripheral.prototype.updateRssiAsync = util.promisify(updateRssi);
+
+const discoverServices = function (uuids, callback) {
   if (callback) {
     this.once('servicesDiscover', services => {
       callback(null, services);
@@ -76,7 +85,10 @@ Peripheral.prototype.discoverServices = function (uuids, callback) {
   this._noble.discoverServices(this.id, uuids);
 };
 
-Peripheral.prototype.discoverSomeServicesAndCharacteristics = function (serviceUuids, characteristicsUuids, callback) {
+Peripheral.prototype.discoverServices = discoverServices;
+Peripheral.prototype.discoverServicesAsync = util.promisify(discoverServices);
+
+const discoverSomeServicesAndCharacteristics = function (serviceUuids, characteristicsUuids, callback) {
   this.discoverServices(serviceUuids, (err, services) => {
     if (err) {
       callback(err, null, null);
@@ -110,11 +122,43 @@ Peripheral.prototype.discoverSomeServicesAndCharacteristics = function (serviceU
   });
 };
 
-Peripheral.prototype.discoverAllServicesAndCharacteristics = function (callback) {
+Peripheral.prototype.discoverSomeServicesAndCharacteristics = discoverSomeServicesAndCharacteristics;
+Peripheral.prototype.discoverSomeServicesAndCharacteristicsAsync = function (serviceUuids, characteristicsUuids) {
+  return new Promise((resolve, reject) =>
+    this.discoverSomeServicesAndCharacteristics(
+      serviceUuids,
+      characteristicsUuids,
+      (error, services, characteristics) =>
+        error
+          ? reject(error)
+          : resolve({
+            services,
+            characteristics
+          })
+    )
+  );
+};
+
+const discoverAllServicesAndCharacteristics = function (callback) {
   this.discoverSomeServicesAndCharacteristics([], [], callback);
 };
 
-Peripheral.prototype.readHandle = function (handle, callback) {
+Peripheral.prototype.discoverAllServicesAndCharacteristics = discoverAllServicesAndCharacteristics;
+Peripheral.prototype.discoverAllServicesAndCharacteristicsAsync = function () {
+  return new Promise((resolve, reject) =>
+    this.discoverAllServicesAndCharacteristics(
+      (error, services, characteristics) =>
+        error
+          ? reject(error)
+          : resolve({
+            services,
+            characteristics
+          })
+    )
+  );
+};
+
+const readHandle = function (handle, callback) {
   if (callback) {
     this.once(`handleRead${handle}`, data => {
       callback(null, data);
@@ -124,7 +168,10 @@ Peripheral.prototype.readHandle = function (handle, callback) {
   this._noble.readHandle(this.id, handle);
 };
 
-Peripheral.prototype.writeHandle = function (handle, data, withoutResponse, callback) {
+Peripheral.prototype.readHandle = readHandle;
+Peripheral.prototype.readHandleAsync = util.promisify(readHandle);
+
+const writeHandle = function (handle, data, withoutResponse, callback) {
   if (!(data instanceof Buffer)) {
     throw new Error('data must be a Buffer');
   }
@@ -137,5 +184,8 @@ Peripheral.prototype.writeHandle = function (handle, data, withoutResponse, call
 
   this._noble.writeHandle(this.id, handle, data, withoutResponse);
 };
+
+Peripheral.prototype.writeHandle = writeHandle;
+Peripheral.prototype.writeHandleAsync = util.promisify(writeHandle);
 
 module.exports = Peripheral;

--- a/lib/service.js
+++ b/lib/service.js
@@ -31,7 +31,7 @@ Service.prototype.toString = function () {
   });
 };
 
-Service.prototype.discoverIncludedServices = function (serviceUuids, callback) {
+const discoverIncludedServices = function (serviceUuids, callback) {
   if (callback) {
     this.once('includedServicesDiscover', includedServiceUuids => {
       callback(null, includedServiceUuids);
@@ -45,7 +45,10 @@ Service.prototype.discoverIncludedServices = function (serviceUuids, callback) {
   );
 };
 
-Service.prototype.discoverCharacteristics = function (characteristicUuids, callback) {
+Service.prototype.discoverIncludedServices = discoverIncludedServices;
+Service.prototype.discoverIncludedServicesAsync = util.promisify(discoverIncludedServices);
+
+const discoverCharacteristics = function (characteristicUuids, callback) {
   if (callback) {
     this.once('characteristicsDiscover', characteristics => {
       callback(null, characteristics);
@@ -58,5 +61,8 @@ Service.prototype.discoverCharacteristics = function (characteristicUuids, callb
     characteristicUuids
   );
 };
+
+Service.prototype.discoverCharacteristics = discoverCharacteristics;
+Service.prototype.discoverCharacteristicsAsync = util.promisify(discoverCharacteristics);
 
 module.exports = Service;


### PR DESCRIPTION
Introduces Promise-returning equivalents for each API method.
The original methods are retained, this is **not** a breaking change.

Usage before:
```javascript
peripheral.discoverServices((error, services) => {
  // callback - handle error and services
});
```

Additional usage possible after this change:
```javascript
try {
  const services = await peripheral.discoverServicesAsync();
  // handle services
} catch (e) {
  // handle error
}
```

**I'd appreciate help with testing**. I've only tried this with a handful of use cases in my project.
If you agree with this proposal, I'd add some Mocha tests.

### Motivation and Context
The current callback-oriented API leads to _callback hell_ – code which is hard to read and maintain – especially given how several operations commonly need to be chained in most common use cases:

```
on discover: (peripheral) ->
  connect to peripheral: () -> 
    discover services: (services) ->
      discover service characteristics: (characteristics) ->
        read characteristic: (data) ->
          handle data
```

Especially with `async/await`, Promise-based code is easier to read and maintain:

```
on discover: (peripheral) ->
  await connect to peripheral
  services = await discover services
  characteristics = await discover service characteristics
  data = await read characteristic
  handle data
```

### Implementation
All exposed methods of all modules – Noble, Peripheral, Service, Characteristic, Descriptor – now have a new Promise-returning counterpart, with an `Async` suffix. 

For example, in addition to
`Peripheral.connect(callback): void`
there is now also 
`Peripheral.connectAsync(): Promise<void>`.

Even though the original callback-based methods are "asynchronous" too, the `Async` suffix was chosen to follow the convention used by [Bluebird's `promisifyAll`](http://bluebirdjs.com/docs/api/promise.promisifyall.html) function, which is commonly used to promisify APIs.

Bluebird was not used in order not to pull in a new dependency. 
Instead, Node's built-in `util.promisify` is used, with two exceptions:
* `discoverAllServicesAndCharacteristicsAsync`
* `discoverSomeServicesAndCharacteristicsAsync`

These two methods use a non-standard callback, passing more than one value argument in addition to error – their signature is `(error, services, characteristics)`. 

To support this proposal, there's a new `peripheral-explorer-async` example, which is just a Promise-based version of the original `peripheral-explorer`.

### Possible Impact Areas
Theoretically shouldn't have any impact on existing code.

### Testing
No tests yet. Will add some later, if there's general agreement with merging this.