### PR TITLE
Fix inconsistencies in method signatures

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,10 +13,16 @@
 
 import events = require("events");
 
-export declare function startScanning(): void;
-export declare function startScanningAsync(): Promise<void>;
-export declare function startScanning(serviceUUIDs: string[], allowDuplicates: boolean, callback?: (error?: Error) => void): void;
-export declare function startScanningAsync(serviceUUIDs: string[], allowDuplicates: boolean): Promise<void>;
+/**
+ * @deprecated
+ */
+export declare function startScanning(callback?: (error?: Error) => void): void;
+/**
+ * @deprecated
+ */
+export declare function startScanning(serviceUUIDs: string[], callback?: (error?: Error) => void): void;
+export declare function startScanning(serviceUUIDs?: string[], allowDuplicates?: boolean, callback?: (error?: Error) => void): void;
+export declare function startScanningAsync(serviceUUIDs?: string[], allowDuplicates?: boolean): Promise<void>;
 export declare function stopScanning(callback?: () => void): void;
 export declare function stopScanningAsync(): Promise<void>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,10 +13,8 @@
 
 import events = require("events");
 
-export declare function startScanning(callback?: (error?: Error) => void): void;
+export declare function startScanning(): void;
 export declare function startScanningAsync(): Promise<void>;
-export declare function startScanning(serviceUUIDs: string[], callback?: (error?: Error) => void): void;
-export declare function startScanningAsync(serviceUUIDs: string[]): Promise<void>;
 export declare function startScanning(serviceUUIDs: string[], allowDuplicates: boolean, callback?: (error?: Error) => void): void;
 export declare function startScanningAsync(serviceUUIDs: string[], allowDuplicates: boolean): Promise<void>;
 export declare function stopScanning(callback?: () => void): void;
@@ -60,6 +58,8 @@ export declare class Peripheral extends events.EventEmitter {
     disconnectAsync(): Promise<void>;
     updateRssi(callback?: (error: string, rssi: number) => void): void;
     updateRssiAsync(): Promise<number>;
+    discoverServices(): void;
+    discoverServicesAsync(): Promise<Service[]>;
     discoverServices(serviceUUIDs: string[], callback?: (error: string, services: Service[]) => void): void;
     discoverServicesAsync(serviceUUIDs: string[]): Promise<Service[]>;
     discoverAllServicesAndCharacteristics(callback?: (error: string, services: Service[], characteristics: Characteristic[]) => void): void;
@@ -98,8 +98,12 @@ export declare class Service extends events.EventEmitter {
     includedServiceUuids: string[];
     characteristics: Characteristic[];
 
+    discoverIncludedServices(): void;
+    discoverIncludedServicesAsync(): Promise<string[]>;
     discoverIncludedServices(serviceUUIDs: string[], callback?: (error: string, includedServiceUuids: string[]) => void): void;
     discoverIncludedServicesAsync(serviceUUIDs: string[]): Promise<string[]>;
+    discoverCharacteristics(): void;
+    discoverCharacteristicsAsync(): Promise<Characteristic[]>;
     discoverCharacteristics(characteristicUUIDs: string[], callback?: (error: string, characteristics: Characteristic[]) => void): void;
     discoverCharacteristicsAsync(characteristicUUIDs: string[]): Promise<Characteristic[]>;
     toString(): string;

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -94,6 +94,14 @@ Noble.prototype.onAddressChange = function (address) {
 };
 
 const startScanning = function (serviceUuids, allowDuplicates, callback) {
+  if (typeof serviceUuids === 'function') {
+    this.emit('warning', 'calling startScanning(callback) is deprecated');
+  }
+
+  if (typeof allowDuplicates === 'function') {
+    this.emit('warning', 'calling startScanning(serviceUuids, callback) is deprecated');
+  }
+
   const scan = function (state) {
     if (state !== 'poweredOn') {
       const error = new Error(`Could not start scanning, state is ${state} (not poweredOn)`);

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -130,7 +130,9 @@ const startScanning = function (serviceUuids, allowDuplicates, callback) {
 };
 
 Noble.prototype.startScanning = startScanning;
-Noble.prototype.startScanningAsync = util.promisify(startScanning);
+Noble.prototype.startScanningAsync = function (serviceUUIDs, allowDuplicates) {
+  return util.promisify((callback) => this.startScanning(serviceUUIDs, allowDuplicates, callback))();
+};
 
 Noble.prototype.onScanStart = function (filterDuplicates) {
   debug('scanStart');

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -86,7 +86,9 @@ const discoverServices = function (uuids, callback) {
 };
 
 Peripheral.prototype.discoverServices = discoverServices;
-Peripheral.prototype.discoverServicesAsync = util.promisify(discoverServices);
+Peripheral.prototype.discoverServicesAsync = function (uuids) {
+  return util.promisify((callback) => this.discoverServices(uuids, callback))();
+};
 
 const discoverSomeServicesAndCharacteristics = function (serviceUuids, characteristicsUuids, callback) {
   this.discoverServices(serviceUuids, (err, services) => {

--- a/lib/service.js
+++ b/lib/service.js
@@ -46,7 +46,9 @@ const discoverIncludedServices = function (serviceUuids, callback) {
 };
 
 Service.prototype.discoverIncludedServices = discoverIncludedServices;
-Service.prototype.discoverIncludedServicesAsync = util.promisify(discoverIncludedServices);
+Service.prototype.discoverIncludedServicesAsync = function (serviceUuids) {
+  return util.promisify((callback) => this.discoverIncludedServices(serviceUuids, callback))();
+};
 
 const discoverCharacteristics = function (characteristicUuids, callback) {
   if (callback) {
@@ -63,6 +65,8 @@ const discoverCharacteristics = function (characteristicUuids, callback) {
 };
 
 Service.prototype.discoverCharacteristics = discoverCharacteristics;
-Service.prototype.discoverCharacteristicsAsync = util.promisify(discoverCharacteristics);
+Service.prototype.discoverCharacteristicsAsync = function (characteristicUuids) {
+  return util.promisify((callback) => this.discoverCharacteristics(characteristicUuids, callback))();
+};
 
 module.exports = Service;


### PR DESCRIPTION
The README, the implementation, and the types diverged in some places:
* removed from `index.d.ts` because it was not actually supported
  * `startScanning(callback)` – `callback` would get passed as `serviceUUIDs`
  * `startScanning(serviceUUIDs, callback)` – `callback` would get passed as `allowDuplicates`
* added to `index.d.ts` (sync and async) because it's in README
  * `discoverIncludedServices()`
  * `discoverCharacteristics()`
  * `discoverServices()`
* fixed the `Async` methods to support the corresponding argumentless calls (`startScanningAsync`, `discoverServicesAsync`, `discoverIncludedServicesAsync`, `discoverCharacteristicsAsync`)

Fixes #57.