### PR TITLE
Fixed tsc error in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,7 @@ export declare var state: string;
 export interface ServicesAndCharacteristics {
   services: Service[];
   characteristics: Characteristic[];
-};
+}
 
 export declare class Peripheral extends events.EventEmitter {
     id: string;


### PR DESCRIPTION
Semicolon throws error when compiling with tsc:

`TS1036: Statements are not allowed in ambient contexts.`