### PR TITLE
Call init and clean listeners when device goes to power on after power off

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -109,6 +109,12 @@ Hci.prototype.pollIsDevUp = function () {
 
   if (this._isDevUp !== isDevUp) {
     if (isDevUp) {
+      if (this._state === 'poweredOff') {
+        this._socket.removeAllListeners();
+        this._state = null;
+        this.init();
+        return;
+      }
       this.setSocketFilter();
       this.setEventMask();
       this.setLeEventMask();


### PR DESCRIPTION
This is a fix that I did sometime ago for Noble but never got merged: https://github.com/noble/noble/pull/861

This small change allows noble to start over when for some reason the device goes to off.
Without it the old instanced objects are used which are not valid anymore.

It is also related to https://github.com/abandonware/noble/issues/53