### PR TITLE
Disallow duplicate service UUID's

### DIFF
--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -358,8 +358,9 @@ Gatt.prototype.discoverServices = function (uuids) {
     if (opcode !== ATT_OP_READ_BY_GROUP_RESP || services[services.length - 1].endHandle === 0xffff) {
       const serviceUuids = [];
       for (i = 0; i < services.length; i++) {
-        if (uuids.length === 0 || uuids.indexOf(services[i].uuid) !== -1) {
-          serviceUuids.push(services[i].uuid);
+        const uuid = services[i].uuid.trim();
+        if ((uuids.length === 0 || uuids.indexOf(uuid) !== -1) && serviceUuids.indexOf(uuid) === -1) {
+          serviceUuids.push(uuid);
         }
 
         this._services[services[i].uuid] = services[i];


### PR DESCRIPTION
Not really sure the root of the issue, but when I was scanning for services on a device from Linux, I was discovering duplicate service UUID's. Blindly adding the duplicates to the list ended up causing problems downstream when doing a discover services and characteristics call...basically got hung up waiting indefinitely for the duplicate UUID's to be searched for characteristics. Anyway, easy fix.