### PR TITLE
Fix bug that noble sometimes does not recognize unsufficient permissions

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -545,7 +545,7 @@ Hci.prototype.onSocketData = function (data) {
 Hci.prototype.onSocketError = function (error) {
   debug(`onSocketError: ${error.message}`);
 
-  if (error.message === 'Operation not permitted') {
+  if (error.code === 'EPERM') {
     this.emit('stateChange', 'unauthorized');
   } else if (error.message === 'Network is down') {
     // no-op


### PR DESCRIPTION
This PR should solve issue #35 (and probably some other issues as well which ultimately stem from unsufficient permissions), that noble sometimes does not properly recognize the "user does not have sufficient permissions" situation correctly.

noble so far tries to recognize this situation by determining if error.message equals "Operation not permitted". But that message seems to have changed in newer versions of node.js, it is now "EPERM, Operation not permitted", causing noble to fail to properly recognize that situation.
As stated in the node.js docs (https://github.com/nodejs/node/blob/master/doc/api/errors.md#errorcode), one should not identify an error via error.message, but via error.code instead:

> The error.code property is a string label that identifies the kind of error. error.code is the most stable way to identify an error. It will only change between major versions of Node.js. In contrast, error.message strings may change between any versions of Node.js.