### PR TITLE
added 5.0 error messages

### DIFF
--- a/lib/hci-socket/hci-status.json
+++ b/lib/hci-socket/hci-status.json
@@ -63,5 +63,9 @@
   "Connection Terminated due to MIC Failure",
   "Connection Failed to be Established",
   "MAC Connection Failed",
-  "Coarse Clock Adjustment Rejected but Will Try to Adjust Using Clock Dragging"
+  "Coarse Clock Adjustment Rejected but Will Try to Adjust Using Clock Dragging",
+  "Type0 Submap Not Defined",
+  "Unknown Advertising Identifier",
+  "Limit Reached",
+  "Operation Cancelled by Host"
 ]


### PR DESCRIPTION
transferred from https://github.com/noble/noble/pull/653

added some missing error messages from BT5

You'll find them in the spec (e.g.): http://www.mouser.li/pdfdocs/bluetooth-Core-v50.pdf
I think I experienced one of the last two. But that was quite a while ago while I was debugging some Bluetooth stuff.