### PR TITLE
Bail early in discoversomeservicesandcharacteristics when the callback would otherwise not fire.

### DIFF
--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -95,7 +95,7 @@ const discoverSomeServicesAndCharacteristics = function (serviceUuids, character
     if (!err && services.length < serviceUuids.length) {
       err = 'Could not find all requested services';
     }
-    
+
     if (err) {
       callback(err, null, null);
       return;

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -92,6 +92,10 @@ Peripheral.prototype.discoverServicesAsync = function (uuids) {
 
 const discoverSomeServicesAndCharacteristics = function (serviceUuids, characteristicsUuids, callback) {
   this.discoverServices(serviceUuids, (err, services) => {
+    if (!err && services.length < serviceUuids.length) { 
+      err = 'Could not find all requested services';
+    }
+    
     if (err) {
       callback(err, null, null);
       return;

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -92,7 +92,7 @@ Peripheral.prototype.discoverServicesAsync = function (uuids) {
 
 const discoverSomeServicesAndCharacteristics = function (serviceUuids, characteristicsUuids, callback) {
   this.discoverServices(serviceUuids, (err, services) => {
-    if (!err && services.length < serviceUuids.length) { 
+    if (!err && services.length < serviceUuids.length) {
       err = 'Could not find all requested services';
     }
     


### PR DESCRIPTION
If the device does not respond with at least the # of requested services, bail early. This keeps the user from relying on a timeout.

The way this is currently written, if the amount of services returned does not match the request, it never calls the callback. It calls the callback when it has processed the same # of services as the request, with no guarantee they are the correct ones requested, and ignoring any extra ones. 

This should also probably have an error path after the for..in loop in case numDiscovered was insufficient, but baby steps.