### PR TITLE
Change address default value on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ noble.on('discover', callback(peripheral));
   };
   ```
 
-__Note:__ On OS X, the address will be set to 'unknown' if the device has not been connected previously.
+__Note:__ On macOS, the address will be set to '' if the device has not been connected previously.
 
 
 #### _Event: Warning raised_


### PR DESCRIPTION
This pull request changes the default address on macOS.

macOS 11.0.1 (20B29).
Noble v1.9.2-10.