### PR TITLE
Add support for acl fragmentation

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -17,6 +17,7 @@ const EVT_DISCONN_COMPLETE = 0x05;
 const EVT_ENCRYPT_CHANGE = 0x08;
 const EVT_CMD_COMPLETE = 0x0e;
 const EVT_CMD_STATUS = 0x0f;
+const EVT_NUMBER_OF_COMPLETED_PACKETS = 0x13;
 const EVT_LE_META_EVENT = 0x3e;
 
 const EVT_LE_CONN_COMPLETE = 0x01;
@@ -34,6 +35,7 @@ const OCF_WRITE_LE_HOST_SUPPORTED = 0x006D;
 
 const OGF_INFO_PARAM = 0x04;
 const OCF_READ_LOCAL_VERSION = 0x0001;
+const OCF_READ_BUFFER_SIZE = 0x0005;
 const OCF_READ_BD_ADDR = 0x0009;
 
 const OGF_STATUS_PARAM = 0x05;
@@ -41,6 +43,7 @@ const OCF_READ_RSSI = 0x0005;
 
 const OGF_LE_CTL = 0x08;
 const OCF_LE_SET_EVENT_MASK = 0x0001;
+const OCF_LE_READ_BUFFER_SIZE = 0x0002;
 const OCF_LE_SET_SCAN_PARAMETERS = 0x000b;
 const OCF_LE_SET_SCAN_ENABLE = 0x000c;
 const OCF_LE_CREATE_CONN = 0x000d;
@@ -55,11 +58,13 @@ const READ_LE_HOST_SUPPORTED_CMD = OCF_READ_LE_HOST_SUPPORTED | OGF_HOST_CTL << 
 const WRITE_LE_HOST_SUPPORTED_CMD = OCF_WRITE_LE_HOST_SUPPORTED | OGF_HOST_CTL << 10;
 
 const READ_LOCAL_VERSION_CMD = OCF_READ_LOCAL_VERSION | (OGF_INFO_PARAM << 10);
+const READ_BUFFER_SIZE_CMD = OCF_READ_BUFFER_SIZE | (OGF_INFO_PARAM << 10);
 const READ_BD_ADDR_CMD = OCF_READ_BD_ADDR | (OGF_INFO_PARAM << 10);
 
 const READ_RSSI_CMD = OCF_READ_RSSI | OGF_STATUS_PARAM << 10;
 
 const LE_SET_EVENT_MASK_CMD = OCF_LE_SET_EVENT_MASK | OGF_LE_CTL << 10;
+const LE_READ_BUFFER_SIZE_CMD = OCF_LE_READ_BUFFER_SIZE | OGF_LE_CTL << 10;
 const LE_SET_SCAN_PARAMETERS_CMD = OCF_LE_SET_SCAN_PARAMETERS | OGF_LE_CTL << 10;
 const LE_SET_SCAN_ENABLE_CMD = OCF_LE_SET_SCAN_ENABLE | OGF_LE_CTL << 10;
 const LE_CREATE_CONN_CMD = OCF_LE_CREATE_CONN | OGF_LE_CTL << 10;
@@ -77,6 +82,15 @@ const Hci = function () {
   this._deviceId = null;
 
   this._handleBuffers = {};
+
+  this._aclBuffers = {
+    length: 0,
+    num: 0
+  };
+
+  this._aclConnections = new Map();
+
+  this._aclQueue = [];
 
   this.on('stateChange', this.onStateChange.bind(this));
 };
@@ -121,6 +135,7 @@ Hci.prototype.pollIsDevUp = function () {
       this.readLocalVersion();
       this.writeLeHostSupported();
       this.readLeHostSupported();
+      this.readLeBufferSize();
       this.readBdAddr();
     } else {
       this.emit('stateChange', 'poweredOff');
@@ -135,7 +150,7 @@ Hci.prototype.pollIsDevUp = function () {
 Hci.prototype.setSocketFilter = function () {
   const filter = Buffer.alloc(14);
   const typeMask = (1 << HCI_COMMAND_PKT) | (1 << HCI_EVENT_PKT) | (1 << HCI_ACLDATA_PKT);
-  const eventMask1 = (1 << EVT_DISCONN_COMPLETE) | (1 << EVT_ENCRYPT_CHANGE) | (1 << EVT_CMD_COMPLETE) | (1 << EVT_CMD_STATUS);
+  const eventMask1 = (1 << EVT_DISCONN_COMPLETE) | (1 << EVT_ENCRYPT_CHANGE) | (1 << EVT_CMD_COMPLETE) | (1 << EVT_CMD_STATUS) | (1 << EVT_NUMBER_OF_COMPLETED_PACKETS);
   const eventMask2 = (1 << (EVT_LE_META_EVENT - 32));
   const opcode = 0;
 
@@ -193,6 +208,20 @@ Hci.prototype.readLocalVersion = function () {
   this._socket.write(cmd);
 };
 
+Hci.prototype.readBufferSize = function () {
+  const cmd = Buffer.alloc(4);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(READ_BUFFER_SIZE_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x0, 3);
+
+  debug(`read buffer size - writing: ${cmd.toString('hex')}`);
+  this._socket.write(cmd);
+};
+
 Hci.prototype.readBdAddr = function () {
   const cmd = Buffer.alloc(4);
 
@@ -221,6 +250,20 @@ Hci.prototype.setLeEventMask = function () {
   leEventMask.copy(cmd, 4);
 
   debug(`set le event mask - writing: ${cmd.toString('hex')}`);
+  this._socket.write(cmd);
+};
+
+Hci.prototype.readLeBufferSize = function () {
+  const cmd = Buffer.alloc(4);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(LE_READ_BUFFER_SIZE_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x0, 3);
+
+  debug(`le read buffer size - writing: ${cmd.toString('hex')}`);
   this._socket.write(cmd);
 };
 
@@ -421,19 +464,60 @@ Hci.prototype.readRssi = function (handle) {
 };
 
 Hci.prototype.writeAclDataPkt = function (handle, cid, data) {
-  const pkt = Buffer.alloc(9 + data.length);
+  const l2capLength = 4 /* l2cap header */ + data.length;
 
-  // header
-  pkt.writeUInt8(HCI_ACLDATA_PKT, 0);
-  pkt.writeUInt16LE(handle | ACL_START_NO_FLUSH << 12, 1);
-  pkt.writeUInt16LE(data.length + 4, 3); // data length 1
-  pkt.writeUInt16LE(data.length, 5); // data length 2
-  pkt.writeUInt16LE(cid, 7);
+  const aclLength = Math.min(l2capLength, this._aclBuffers.length);
 
-  data.copy(pkt, 9);
+  const first = Buffer.alloc(aclLength + 5 /* acl header */);
 
-  debug(`write acl data pkt - writing: ${pkt.toString('hex')}`);
-  this._socket.write(pkt);
+  // acl header
+  first.writeUInt8(HCI_ACLDATA_PKT, 0);
+  first.writeUInt16LE(handle | ACL_START_NO_FLUSH << 12, 1);
+  first.writeUInt16LE(aclLength, 3);
+
+  // l2cap header
+  first.writeUInt16LE(data.length, 5);
+  first.writeUInt16LE(cid, 7);
+
+  data.copy(first, 9);
+  data = data.slice(first.length - 9);
+
+  debug(`push to acl queue: ${first.toString('hex')}`);
+  this._aclQueue.push({ handle, packet: first });
+
+  while (data.length > 0) {
+    const fragAclLength = Math.min(data.length, this._aclBuffers.length);
+    const frag = Buffer.alloc(fragAclLength + 5 /* acl header */);
+    // acl header
+    frag.writeUInt8(HCI_ACLDATA_PKT, 0);
+    frag.writeUInt16LE(handle | ACL_CONT << 12, 1);
+    frag.writeUInt16LE(fragAclLength, 3);
+
+    data.copy(frag, 5);
+    data = data.slice(frag.length - 5);
+
+    debug(`push fragment to acl queue: ${frag.toString('hex')}`);
+    this._aclQueue.push({ handle, packet: frag });
+  }
+
+  this.flushAcl();
+};
+
+Hci.prototype.flushAcl = function () {
+  const pendingPackets = () => {
+    let totalPending = 0;
+    for (const { pending } of this._aclConnections.values()) { totalPending += pending; }
+    return totalPending;
+  };
+
+  debug(`flush - pending: ${pendingPackets()} queue length: ${this._aclQueue.length}`);
+
+  while (this._aclQueue.length > 0 && pendingPackets() < this._aclBuffers.num) {
+    const { handle, packet } = this._aclQueue.shift();
+    this._aclConnections.get(handle).pending++;
+    debug(`write acl data packet - writing: ${packet.toString('hex')}`);
+    this._socket.write(packet);
+  }
 };
 
 Hci.prototype.onSocketData = function (data) {
@@ -457,6 +541,10 @@ Hci.prototype.onSocketData = function (data) {
 
       debug(`\t\thandle = ${handle}`);
       debug(`\t\treason = ${reason}`);
+
+      this._aclQueue = this._aclQueue.filter(acl => acl.handle !== handle);
+      this._aclConnections.delete(handle);
+      this.flushAcl();
 
       this.emit('disconnComplete', handle, reason);
     } else if (subEventType === EVT_ENCRYPT_CHANGE) {
@@ -495,6 +583,26 @@ Hci.prototype.onSocketData = function (data) {
       debug(`\t\tLE meta event data = ${leMetaEventData.toString('hex')}`);
 
       this.processLeMetaEvent(leMetaEventType, leMetaEventStatus, leMetaEventData);
+    } else if (subEventType === EVT_NUMBER_OF_COMPLETED_PACKETS) {
+      const handles = data.readUInt8(3);
+      for (let h = 0; h < handles; h++) {
+        const handle = data.readUInt16LE(4 + h * 4);
+        const pkts = data.readUInt16LE(6 + h * 4);
+        debug(`\thandle = ${handle}`);
+        debug(`\t\tcompleted = ${pkts}`);
+
+        if (!this._aclConnections.has(handle)) {
+          debug('\t\tclosed');
+          continue;
+        }
+
+        const connection = this._aclConnections.get(handle);
+
+        connection.pending -= pkts;
+
+        if (connection.pending < 0) { connection.pending = 0; }
+      }
+      this.flushAcl();
     }
   } else if (HCI_ACLDATA_PKT === eventType) {
     const flags = data.readUInt16LE(1) >> 12;
@@ -616,6 +724,29 @@ Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
     debug(`\t\t\trssi = ${rssi}`);
 
     this.emit('rssiRead', handle, rssi);
+  } else if (cmd === LE_READ_BUFFER_SIZE_CMD) {
+    if (status === 0) {
+      const aclLength = result.readUInt16LE(0);
+      const aclNum = result.readUInt8(2);
+
+      /* Spec Vol 4 Part E.7.8
+      /* No dedicated LE Buffer exists. Use the HCI_Read_Buffer_Size command. */
+      if (aclLength === 0 || aclNum === 0) {
+        debug('using br/edr buffer size');
+        this.readBufferSize();
+      } else {
+        debug(`le buffer size: length = ${aclLength}, num = ${aclNum}`);
+        this._aclBuffers.length = aclLength;
+        this._aclBuffers.num = aclNum;
+      }
+    }
+  } else if (cmd === READ_BUFFER_SIZE_CMD) {
+    const aclLength = result.readUInt16LE(0);
+    const aclNum = result.readUInt16LE(3);
+
+    debug(`buffer size: length = ${aclLength}, num = ${aclNum}`);
+    this._aclBuffers.length = aclLength;
+    this._aclBuffers.num = aclNum;
   }
 };
 
@@ -647,6 +778,8 @@ Hci.prototype.processLeConnComplete = function (status, data) {
   debug(`\t\t\tlatency = ${latency}`);
   debug(`\t\t\tsupervision timeout = ${supervisionTimeout}`);
   debug(`\t\t\tmaster clock accuracy = ${masterClockAccuracy}`);
+
+  this._aclConnections.set(handle, { pending: 0 });
 
   this.emit('leConnComplete', status, handle, role, addressType, address, interval, latency, supervisionTimeout, masterClockAccuracy);
 };


### PR DESCRIPTION
ACL fragmentation is required to send ACL payload bigger than the controller buffer size, so for example if you `write` a big payload on an handle