### PR TITLE
Fix out of range errors for malformed EIR data.

### DIFF
--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -142,7 +142,7 @@ Gap.prototype.onHciLeAdvertisingReport = function (status, type, address, addres
     switch (eirType) {
       case 0x02: // Incomplete List of 16-bit Service Class UUID
       case 0x03: // Complete List of 16-bit Service Class UUIDs
-        for (let j = 0; j < bytes.length; j += 2) {
+        for (let j = 0; j < bytes.length - 1; j += 2) {
           const serviceUuid = bytes.readUInt16LE(j).toString(16);
           if (advertisement.serviceUuids.indexOf(serviceUuid) === -1) {
             advertisement.serviceUuids.push(serviceUuid);
@@ -152,7 +152,7 @@ Gap.prototype.onHciLeAdvertisingReport = function (status, type, address, addres
 
       case 0x06: // Incomplete List of 128-bit Service Class UUIDs
       case 0x07: // Complete List of 128-bit Service Class UUIDs
-        for (let j = 0; j < bytes.length; j += 16) {
+        for (let j = 0; j < bytes.length - 15; j += 16) {
           const serviceUuid = bytes.slice(j, j + 16).toString('hex').match(/.{1,2}/g).reverse().join('');
           if (advertisement.serviceUuids.indexOf(serviceUuid) === -1) {
             advertisement.serviceUuids.push(serviceUuid);
@@ -170,7 +170,7 @@ Gap.prototype.onHciLeAdvertisingReport = function (status, type, address, addres
         break;
 
       case 0x14: // List of 16 bit solicitation UUIDs
-        for (let j = 0; j < bytes.length; j += 2) {
+        for (let j = 0; j < bytes.length - 1; j += 2) {
           const serviceSolicitationUuid = bytes.readUInt16LE(j).toString(16);
           if (advertisement.serviceSolicitationUuids.indexOf(serviceSolicitationUuid) === -1) {
             advertisement.serviceSolicitationUuids.push(serviceSolicitationUuid);
@@ -179,7 +179,7 @@ Gap.prototype.onHciLeAdvertisingReport = function (status, type, address, addres
         break;
 
       case 0x15: // List of 128 bit solicitation UUIDs
-        for (let j = 0; j < bytes.length; j += 16) {
+        for (let j = 0; j < bytes.length - 15; j += 16) {
           const serviceSolicitationUuid = bytes.slice(j, j + 16).toString('hex').match(/.{1,2}/g).reverse().join('');
           if (advertisement.serviceSolicitationUuids.indexOf(serviceSolicitationUuid) === -1) {
             advertisement.serviceSolicitationUuids.push(serviceSolicitationUuid);
@@ -209,7 +209,7 @@ Gap.prototype.onHciLeAdvertisingReport = function (status, type, address, addres
         break;
 
       case 0x1f: // List of 32 bit solicitation UUIDs
-        for (let j = 0; j < bytes.length; j += 4) {
+        for (let j = 0; j < bytes.length - 3; j += 4) {
           const serviceSolicitationUuid = bytes.readUInt32LE(j).toString(16);
           if (advertisement.serviceSolicitationUuids.indexOf(serviceSolicitationUuid) === -1) {
             advertisement.serviceSolicitationUuids.push(serviceSolicitationUuid);


### PR DESCRIPTION
This PR aims to make the code safer by preventing buffer overrun errors.

The strategy is to guarantee the `bytes` buffer will have sufficient data for each
possible starting reading position of the `j` variable.

# The problem

We've sometimes encountered in the wild devices that have malformed
EIR data structures.

For example, we've found the device `1c:52:16:b8:6a:f2` that
provided the `eir` buffer with data:
`[30,3,18,162,77,46,254,20,72,142,147,210,23,60,253,2,48,128,74,92,243,232,188,150,82,60,64,0,0,0,0]`.
This caused an out of bounds error on line 146, when
calling function `bytes.readUInt16LE(j)`
with `j = 28` which fails, since we're trying to read two bytes
starting from position 28 when `bytes` has only 29 elements.

The proposed solution respects the bounds of the `bytes` buffer when
reading from its positions directly.

# How to reproduce

While running scan on one device using noble, use another bluetooth-enabled linux device
to run a service with malformed EIR data by executing these commands:

```
sudo hciconfig hci0 up
sudo hciconfig hci0 leadv 3
sudo hcitool -i hci0 cmd 0x08 0x0008 05 04 03 02 01 00
```

This will cause the library without this fix to crash as shown in this image:

![Screen Shot 2021-01-07 at 09 37 26](https://user-images.githubusercontent.com/1574161/103893666-6ac86300-50cc-11eb-9cb3-d24f5eabca5a.png)

# Collaborators

Thanks to Pedro Santana for providing the detailed crash information.
Thanks to Filipe Carvalhedo for helping out with the fix and providing a way to reproduce the crash.