### PR TITLE
Fix some typescript declaration issues

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,7 @@ export declare function startScanning(serviceUUIDs?: string[], allowDuplicates?:
 export declare function startScanningAsync(serviceUUIDs?: string[], allowDuplicates?: boolean): Promise<void>;
 export declare function stopScanning(callback?: () => void): void;
 export declare function stopScanningAsync(): Promise<void>;
+export declare function reset(): void;
 
 export declare function on(event: "stateChange", listener: (state: string) => void): events.EventEmitter;
 export declare function on(event: "scanStart", listener: () => void): events.EventEmitter;

--- a/index.d.ts
+++ b/index.d.ts
@@ -147,8 +147,8 @@ export declare class Characteristic extends events.EventEmitter {
 
     read(callback?: (error: string, data: Buffer) => void): void;
     readAsync(): Promise<Buffer>;
-    write(data: Buffer, notify: boolean, callback?: (error: string) => void): void;
-    writeAsync(data: Buffer, notify: boolean): Promise<void>;
+    write(data: Buffer, withoutResponse: boolean, callback?: (error: string) => void): void;
+    writeAsync(data: Buffer, withoutResponse: boolean): Promise<void>;
     broadcast(broadcast: boolean, callback?: (error: string) => void): void;
     broadcastAsync(broadcast: boolean): Promise<void>;
     notify(notify: boolean, callback?: (error: string) => void): void;


### PR DESCRIPTION
As I've been working with noble, I've noticed a few TypeScript declarations that are missing or don't line up with the actual code:

- `noble.reset()`: declaration is missing
- `Characteristic.write()`: according to the [Noble source](https://github.com/abandonware/noble/blob/dd1546237103849757faaebd67e32d0418c59896/lib/characteristic.js#L62), the second parameter of `write()` is `withoutResponse`. The parameter currently in the declaration file, `notify`, implies the opposite.