### PR TITLE
Re-implement subset of ThreadSafeCallback using thread safe function from napi

### DIFF
--- a/lib/mac/binding.gyp
+++ b/lib/mac/binding.gyp
@@ -3,7 +3,7 @@
     {
       'target_name': 'binding',
       'sources': [ 'src/noble_mac.mm', 'src/napi_objc.mm', 'src/ble_manager.mm', 'src/objc_cpp.mm', 'src/callbacks.cc'  ],
-      'include_dirs': ["<!@(node -p \"require('node-addon-api').include\")", "<!@(node -p \"require('napi-thread-safe-callback').include\")"],
+      'include_dirs': ["<!@(node -p \"require('node-addon-api').include\")"],
       'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],

--- a/lib/mac/src/callbacks.cc
+++ b/lib/mac/src/callbacks.cc
@@ -6,8 +6,6 @@
 //
 #include "callbacks.h"
 
-#include <napi-thread-safe-callback.hpp>
-
 #define _s(val) Napi::String::New(env, val)
 #define _b(val) Napi::Boolean::New(env, val)
 #define _n(val) Napi::Number::New(env, val)

--- a/lib/mac/src/callbacks.h
+++ b/lib/mac/src/callbacks.h
@@ -3,7 +3,61 @@
 #include <napi.h>
 #include "peripheral.h"
 
-class ThreadSafeCallback;
+class ThreadSafeCallback {
+  using arg_vector_t = std::vector<napi_value>;
+  using arg_func_t = std::function<void(napi_env, arg_vector_t &)>;
+
+  static void callJsCallback(Napi::Env env,
+                             Napi::Function jsCallback,
+                             Napi::Reference<Napi::Value> *context,
+                             arg_func_t *argfn) {
+    if (argfn != nullptr) {
+      arg_vector_t args;
+
+      (*argfn)(env, args);
+      delete argfn;
+
+      if (env != nullptr && jsCallback != nullptr)
+        jsCallback.Call(context->Value(), args);
+    }
+  };
+  using tsfn_t = Napi::TypedThreadSafeFunction<
+    Napi::Reference<Napi::Value>, arg_func_t, callJsCallback>;
+
+public:
+  ThreadSafeCallback(const Napi::Value &receiver,
+                     const Napi::Function &jsCallback) {
+    if (!(receiver.IsObject() || receiver.IsFunction()))
+      throw Napi::Error::New(jsCallback.Env(),
+                             "Callback receiver must be an object or function");
+    if (!jsCallback.IsFunction())
+      throw Napi::Error::New(jsCallback.Env(), "Callback must be a function");
+
+    receiver_ = Napi::Persistent(receiver);
+    tsfn_ = tsfn_t::New(jsCallback.Env(),
+                        jsCallback,
+                        "ThreadSafeCallback callback",
+                        0, 1, &receiver_);
+  }
+  ~ThreadSafeCallback() {
+    // No further interaction with the thread safe function allowed.
+    tsfn_.Abort();
+  }
+  void call(arg_func_t arg_function) {
+    arg_func_t *argfn = new arg_func_t(arg_function);
+    if (tsfn_.BlockingCall(argfn) != napi_ok)
+      delete argfn;
+  };
+
+protected:
+  ThreadSafeCallback(const ThreadSafeCallback &) = delete;
+  ThreadSafeCallback& operator=(const ThreadSafeCallback &) = delete;
+  ThreadSafeCallback& operator=(ThreadSafeCallback &&) = delete;
+
+private:
+  Napi::Reference<Napi::Value> receiver_;
+  tsfn_t tsfn_;
+};
 
 class Emit {
 public:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2307,11 +2307,6 @@
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
       "optional": true
     },
-    "napi-thread-safe-callback": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/napi-thread-safe-callback/-/napi-thread-safe-callback-0.0.6.tgz",
-      "integrity": "sha512-X7uHCOCdY4u0yamDxDrv3jF2NtYc8A1nvPzBQgvpoSX+WB3jAe2cVNsY448V1ucq7Whf9Wdy02HEUoLW5rJKWg=="
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   ],
   "dependencies": {
     "debug": "^4.3.1",
-    "napi-thread-safe-callback": "0.0.6",
     "node-addon-api": "^3.2.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
This PR implements subset of ThreadSafeCallback class, originally provided by napi-thread-safe-callback npm, on the top of thread safe function provided by node api, expecting to fix issue #215 