### PR TITLE
Fix #217 and deprecation warnings on install

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -117,7 +117,10 @@ Hci.prototype.init = function (options) {
 
     this.reset();
   } else {
-    this._socket.bindRaw(this._deviceId);
+    if (!this._bound) {
+       this._socket.bindRaw(this._deviceId);
+       this._bound = true;
+    }
     this._socket.start();
 
     this.pollIsDevUp();

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "devDependencies": {
     "async": "^3.2.0",
     "eslint": "^7.27.0",
-    "eslint-config-semistandard": "^15.0.1",
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-import": "^2.23.3",
     "eslint-plugin-node": "^11.1.0",
@@ -51,7 +50,7 @@
     "eslint-plugin-standard": "^5.0.0",
     "install": "^0.13.0",
     "mocha": "^8.4.0",
-    "node-gyp": "^8.0.0",
+    "@mapbox/node-pre-gyp": "^1.0.5",
     "prettier": "^2.3.0",
     "proxyquire": "^2.1.3",
     "should": "~13.2.3",


### PR DESCRIPTION
This PR fixes a crash of noble / NodeJS when (re-enabling Bluetooth on a Raspberrry Pi, see #217.

It also addresses the deprecation warnings on install, by switching to @mapbox/node-pre-gyp (cf. https://github.com/abandonware/node-bluetooth-hci-socket/issues/26) and removing the dev dependency on eslint-config-semistandard.

To get rid of all the deprecation warnings, a new version of node-bluetooth-hci-socket would need to be published, see https://github.com/abandonware/node-bluetooth-hci-socket/issues/30.

I really appreciate the work you're doing here.  Please let met me know how I can help. 