### PR TITLE
Handle BLE MTU change requests

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -231,7 +231,9 @@ NobleBindings.prototype.onLeConnComplete = function (status, handle, role, addre
 
     this._signalings[handle].on('connectionParameterUpdateRequest', this.onConnectionParameterUpdateRequest.bind(this));
 
-    this._gatts[handle].exchangeMtu(256);
+    setTimeout(() => {
+      this._gatts[handle].exchangeMtu();
+    }, 0);
   } else {
     uuid = this._pendingConnectionUuid;
     let statusMessage = Hci.STATUS_MAPPER[status] || 'HCI Error: Unknown';

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -330,7 +330,7 @@ Gatt.prototype.handleConfirmation = function () {
 };
 
 Gatt.prototype.exchangeMtu = function() {
-  this._queueCommand(this.mtuRequest(this._desired_mtu), function(data) {
+  this._queueCommand(this.mtuRequest(this._desired_mtu), (data) => {
     const opcode = data[0];
 
     if (opcode === ATT_OP_MTU_RESP) {

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -69,6 +69,7 @@ const Gatt = function (address, aclStream) {
   this._commandQueue = [];
 
   this._mtu = 23;
+  this._desired_mtu = 512;
   this._security = 'low';
 
   this.onAclStreamDataBinded = this.onAclStreamData.bind(this);
@@ -96,8 +97,13 @@ Gatt.prototype.onAclStreamData = function (cid, data) {
       debug(`${this._address}: multi-role flag in use, ignoring command meant for peripheral role.`);
     } else {
       const requestType = data[0];
-      debug(`${this._address}: replying with REQ_NOT_SUPP to 0x${requestType.toString(16)}`);
-      this.writeAtt(this.errorResponse(requestType, 0x0000, ATT_ECODE_REQ_NOT_SUPP));
+      if (requestType == ATT_OP_MTU_REQ) {
+        debug(this._address + ': replying to MTU request');
+        this.writeAtt(this.mtuResponse(this._desired_mtu));
+      } else {
+        debug(this._address + ': replying with REQ_NOT_SUPP to 0x' + requestType.toString(16));
+        this.writeAtt(this.errorResponse(requestType, 0x0000, ATT_ECODE_REQ_NOT_SUPP));
+      }
     }
   } else if (data[0] === ATT_OP_HANDLE_NOTIFY || data[0] === ATT_OP_HANDLE_IND) {
     const valueHandle = data.readUInt16LE(1);
@@ -219,6 +225,15 @@ Gatt.prototype.mtuRequest = function (mtu) {
   return buf;
 };
 
+Gatt.prototype.mtuResponse = function(mtu) {
+  const buf = Buffer.alloc(3);
+
+  buf.writeUInt8(ATT_OP_MTU_RESP, 0);
+  buf.writeUInt16LE(mtu, 1);
+
+  return buf;
+};
+
 Gatt.prototype.readByGroupRequest = function (startHandle, endHandle, groupUuid) {
   const buf = Buffer.alloc(7);
 
@@ -314,8 +329,8 @@ Gatt.prototype.handleConfirmation = function () {
   return buf;
 };
 
-Gatt.prototype.exchangeMtu = function (mtu) {
-  this._queueCommand(this.mtuRequest(mtu), (data) => {
+Gatt.prototype.exchangeMtu = function() {
+  this._queueCommand(this.mtuRequest(this._desired_mtu), function(data) {
     const opcode = data[0];
 
     if (opcode === ATT_OP_MTU_RESP) {

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -69,7 +69,7 @@ const Gatt = function (address, aclStream) {
   this._commandQueue = [];
 
   this._mtu = 23;
-  this._desired_mtu = 512;
+  this._desired_mtu = 256;
   this._security = 'low';
 
   this.onAclStreamDataBinded = this.onAclStreamData.bind(this);

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -97,11 +97,11 @@ Gatt.prototype.onAclStreamData = function (cid, data) {
       debug(`${this._address}: multi-role flag in use, ignoring command meant for peripheral role.`);
     } else {
       const requestType = data[0];
-      if (requestType == ATT_OP_MTU_REQ) {
-        debug(this._address + ': replying to MTU request');
+      if (requestType === ATT_OP_MTU_REQ) {
+        debug(`${this._address}: replying to MTU request`);
         this.writeAtt(this.mtuResponse(this._desired_mtu));
       } else {
-        debug(this._address + ': replying with REQ_NOT_SUPP to 0x' + requestType.toString(16));
+        debug(`${this._address}: replying with REQ_NOT_SUPP to 0x${requestType.toString(16)}`);
         this.writeAtt(this.errorResponse(requestType, 0x0000, ATT_ECODE_REQ_NOT_SUPP));
       }
     }

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -225,7 +225,7 @@ Gatt.prototype.mtuRequest = function (mtu) {
   return buf;
 };
 
-Gatt.prototype.mtuResponse = function(mtu) {
+Gatt.prototype.mtuResponse = function (mtu) {
   const buf = Buffer.alloc(3);
 
   buf.writeUInt8(ATT_OP_MTU_RESP, 0);
@@ -329,7 +329,7 @@ Gatt.prototype.handleConfirmation = function () {
   return buf;
 };
 
-Gatt.prototype.exchangeMtu = function() {
+Gatt.prototype.exchangeMtu = function () {
   this._queueCommand(this.mtuRequest(this._desired_mtu), (data) => {
     const opcode = data[0];
 


### PR DESCRIPTION
I've noticed a lot of weird failures with noble that seem to be centered around devices that attempt to renegotiate the MTU size after the initial MTU exchange has already occurred. This behavior is somewhat rare, but there *are* devices that do this, and as far as I can tell, the BLE spec allows it. Other BLE Central software appears to support these MTU change requests (e.g. the BlueZ GATT client and the Android BLE API). 

Noble doesn't currently handle this. If it receives an ATT_OP_MTU_REQ message after the initial MTU exchange, it responds with REQ_NOT_SUPP. As you can imagine, some devices handle this more gracefully than others. 

This pull request gives noble basic support for MTU change requests. My company has been using noble with these modifications for the past year or so, and it appears to be working well. 

Possibly fixes #222 