### PR TITLE
feat: add ble5 extended advertising scanning for the hci binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ __Note:__ macOS / Mac OS X, Linux, FreeBSD and Windows are currently the only su
 ```javascript
 // Read the battery level of the first found peripheral exposing the Battery Level characteristic
 
-const noble = require('@abandonware/noble');
+const noble = require('@abandonware/noble')({extended: false});
 
 noble.on('stateChange', async (state) => {
   if (state === 'poweredOn') {
@@ -125,6 +125,7 @@ npm install --global --production windows-build-tools
 ```
 
 [node-bluetooth-hci-socket prerequisites](#windows)
+   * Compatible Bluetooth 5.0 Zephyr HCI-USB adapter (you need to add BLUETOOTH_HCI_SOCKET_USB_VID and BLUETOOTH_HCI_SOCKET_USB_PID to the process env)
    * Compatible Bluetooth 4.0 USB adapter
    * [WinUSB](https://msdn.microsoft.com/en-ca/library/windows/hardware/ff540196(v=vs.85).aspx) driver setup for Bluetooth 4.0 USB adapter, using [Zadig tool](http://zadig.akeo.ie/)
 
@@ -140,8 +141,14 @@ Make sur your container runs with `--network=host` options and all specific envi
 npm install @abandonware/noble
 ```
 
+In Windows OS add your custom hci-usb dongle to the process env
+```sh
+set BLUETOOTH_HCI_SOCKET_USB_VID=xxx
+set BLUETOOTH_HCI_SOCKET_USB_PID=xxx
+```
+
 ```javascript
-const noble = require('@abandonware/noble');
+const noble = require('@abandonware/noble')({extended: false});
 ```
 
 ## API docs
@@ -652,7 +659,8 @@ const Noble = require('@abandonware/noble/lib/noble');
 
 const params = {
   deviceId: 0,
-  userChannel: true
+  userChannel: true,
+  extended: false
 };
 
 const noble = new Noble(new HCIBindings(params));

--- a/examples/advertisement-discovery.js
+++ b/examples/advertisement-discovery.js
@@ -1,35 +1,65 @@
-const noble = require('../index');
+const noble = require('../index')({ extended: false });
 
 noble.on('stateChange', function (state) {
   if (state === 'poweredOn') {
-    noble.startScanning();
+    noble.startScanning([], false);
   } else {
     noble.stopScanning();
   }
 });
 
 noble.on('discover', function (peripheral) {
-  console.log(`peripheral discovered (${peripheral.id} with address <${peripheral.address}, ${peripheral.addressType}>, connectable ${peripheral.connectable}, RSSI ${peripheral.rssi}:`);
+  console.log(`${new Date()}`);
+  console.log(
+    `Peripheral discovered (${peripheral.id} with address <${peripheral.address}, ${peripheral.addressType}>, connectable: ${peripheral.connectable}, scannable: ${peripheral.scannable}, RSSI ${peripheral.rssi}:`
+  );
   console.log('\thello my local name is:');
   console.log(`\t\t${peripheral.advertisement.localName}`);
-  console.log('\tcan I interest you in any of the following advertised services:');
+  console.log(
+    '\tcan I interest you in any of the following advertised services:'
+  );
   console.log(`\t\t${JSON.stringify(peripheral.advertisement.serviceUuids)}`);
-
   const serviceData = peripheral.advertisement.serviceData;
+
   if (serviceData && serviceData.length) {
     console.log('\there is my service data:');
     for (const i in serviceData) {
-      console.log(`\t\t${JSON.stringify(serviceData[i].uuid)}: ${JSON.stringify(serviceData[i].data.toString('hex'))}`);
+      console.log(
+        `\t\t${JSON.stringify(serviceData[i].uuid)}: ${JSON.stringify(
+          serviceData[i].data.toString('hex')
+        )}`
+      );
     }
   }
+
   if (peripheral.advertisement.manufacturerData) {
     console.log('\there is my manufacturer data:');
-    console.log(`\t\t${JSON.stringify(peripheral.advertisement.manufacturerData.toString('hex'))}`);
+    console.log(
+      `\t\t${JSON.stringify(
+        peripheral.advertisement.manufacturerData.toString('hex')
+      )}`
+    );
   }
+
   if (peripheral.advertisement.txPowerLevel !== undefined) {
     console.log('\tmy TX power level is:');
     console.log(`\t\t${peripheral.advertisement.txPowerLevel}`);
   }
 
   console.log();
+});
+
+process.on('SIGINT', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});
+
+process.on('SIGQUIT', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});
+
+process.on('SIGTERM', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
 });

--- a/examples/cache-gatt-reconnect.js
+++ b/examples/cache-gatt-reconnect.js
@@ -6,7 +6,7 @@
  * Prints timing information from discovered to connected to reading states.
  */
 
-const noble = require('../index');
+const noble = require('../index')({ extended: false });
 const fs = require('fs');
 
 // the sensor value to scan for, number of bits and factor for displaying it
@@ -18,7 +18,7 @@ const EXT = '.dump';
 
 noble.on('stateChange', function (state) {
   if (state === 'poweredOn') {
-    noble.startScanning();
+    noble.startScanning([], false);
   } else {
     noble.stopScanning();
   }
@@ -35,7 +35,9 @@ let meta = {
 };
 
 noble.on('discover', function (peripheral) {
-  console.log(`peripheral discovered (${peripheral.id} with address <${peripheral.address}, ${peripheral.addressType}>, connectable ${peripheral.connectable}, RSSI ${peripheral.rssi}:`);
+  console.log(
+    `peripheral discovered (${peripheral.id} with address <${peripheral.address}, ${peripheral.addressType}>, connectable ${peripheral.connectable}, RSSI ${peripheral.rssi}:`
+  );
   console.log('\thello my local name is:');
   console.log(`\t\t${peripheral.advertisement.localName}`);
   console.log();
@@ -126,11 +128,17 @@ const setData = function (peripheral, meta) {
     const charas = meta.characteristics[service.uuid];
     console.log(`\tservice ${i} ${service} ${JSON.stringify(charas)}`);
 
-    const characteristics = noble.addCharacteristics(peripheral.uuid, service.uuid, charas);
+    const characteristics = noble.addCharacteristics(
+      peripheral.uuid,
+      service.uuid,
+      charas
+    );
 
     for (const j in characteristics) {
       const characteristic = characteristics[j];
-      console.log(`\t\tcharac ${service.uuid} ${j} ${characteristic} ${characteristic.rawProps}`);
+      console.log(
+        `\t\tcharac ${service.uuid} ${j} ${characteristic} ${characteristic.rawProps}`
+      );
       if (characteristic.name === CHANNEL) {
         console.log(`\t\t\t-->found ${CHANNEL} characteristic!`);
         sensorCharacteristic = characteristic;
@@ -139,3 +147,18 @@ const setData = function (peripheral, meta) {
   }
   return sensorCharacteristic;
 };
+
+process.on('SIGINT', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});
+
+process.on('SIGQUIT', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});
+
+process.on('SIGTERM', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});

--- a/examples/echo.js
+++ b/examples/echo.js
@@ -6,21 +6,21 @@
 // start an interval to write data to the characteristic
 
 // const noble = require('noble');
-const noble = require('..');
+const noble = require('..')({ extended: false });
 
 const ECHO_SERVICE_UUID = 'ec00';
 const ECHO_CHARACTERISTIC_UUID = 'ec0e';
 
-noble.on('stateChange', state => {
+noble.on('stateChange', (state) => {
   if (state === 'poweredOn') {
     console.log('Scanning');
-    noble.startScanning([ECHO_SERVICE_UUID]);
+    noble.startScanning([ECHO_SERVICE_UUID], false);
   } else {
     noble.stopScanning();
   }
 });
 
-noble.on('discover', peripheral => {
+noble.on('discover', (peripheral) => {
   // connect to the first peripheral that is scanned
   noble.stopScanning();
   const name = peripheral.advertisement.localName;
@@ -29,7 +29,7 @@ noble.on('discover', peripheral => {
 });
 
 function connectAndSetUp (peripheral) {
-  peripheral.connect(error => {
+  peripheral.connect((error) => {
     if (error) {
       console.error(error);
       return;
@@ -51,7 +51,11 @@ function connectAndSetUp (peripheral) {
   peripheral.on('disconnect', () => console.log('disconnected'));
 }
 
-function onServicesAndCharacteristicsDiscovered (error, services, characteristics) {
+function onServicesAndCharacteristicsDiscovered (
+  error,
+  services,
+  characteristics
+) {
   if (error) {
     console.error(error);
     return;
@@ -66,7 +70,7 @@ function onServicesAndCharacteristicsDiscovered (error, services, characteristic
   });
 
   // subscribe to be notified whenever the peripheral update the characteristic
-  echoCharacteristic.subscribe(error => {
+  echoCharacteristic.subscribe((error) => {
     if (error) {
       console.error('Error subscribing to echoCharacteristic');
     } else {
@@ -83,3 +87,18 @@ function onServicesAndCharacteristicsDiscovered (error, services, characteristic
     echoCharacteristic.write(message);
   }, 2500);
 }
+
+process.on('SIGINT', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});
+
+process.on('SIGQUIT', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});
+
+process.on('SIGTERM', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});

--- a/examples/enter-exit.js
+++ b/examples/enter-exit.js
@@ -7,7 +7,7 @@
 
   based on code provided by: Mattias Ask (http://www.dittlof.com)
 */
-const noble = require('../index');
+const noble = require('../index')({ extended: false });
 
 const RSSI_THRESHOLD = -90;
 const EXIT_GRACE_PERIOD = 2000; // milliseconds
@@ -28,7 +28,11 @@ noble.on('discover', function (peripheral) {
       peripheral: peripheral
     };
 
-    console.log(`"${peripheral.advertisement.localName}" entered (RSSI ${peripheral.rssi}) ${new Date()}`);
+    console.log(
+      `"${peripheral.advertisement.localName}" entered (RSSI ${
+        peripheral.rssi
+      }) ${new Date()}`
+    );
   }
 
   inRange[id].lastSeen = Date.now();
@@ -36,10 +40,14 @@ noble.on('discover', function (peripheral) {
 
 setInterval(function () {
   for (const id in inRange) {
-    if (inRange[id].lastSeen < (Date.now() - EXIT_GRACE_PERIOD)) {
+    if (inRange[id].lastSeen < Date.now() - EXIT_GRACE_PERIOD) {
       const peripheral = inRange[id].peripheral;
 
-      console.log(`"${peripheral.advertisement.localName}" exited (RSSI ${peripheral.rssi}) ${new Date()}`);
+      console.log(
+        `"${peripheral.advertisement.localName}" exited (RSSI ${
+          peripheral.rssi
+        }) ${new Date()}`
+      );
 
       delete inRange[id];
     }
@@ -52,4 +60,19 @@ noble.on('stateChange', function (state) {
   } else {
     noble.stopScanning();
   }
+});
+
+process.on('SIGINT', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});
+
+process.on('SIGQUIT', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});
+
+process.on('SIGTERM', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
 });

--- a/examples/peripheral-explorer-async.js
+++ b/examples/peripheral-explorer-async.js
@@ -1,4 +1,4 @@
-const noble = require('../');
+const noble = require('../')({ extended: false });
 
 const peripheralIdOrAddress = process.argv[2].toLowerCase();
 
@@ -34,7 +34,9 @@ noble.on('discover', async (peripheral) => {
     }
 
     if (serviceData) {
-      console.log(`  Service Data      = ${JSON.stringify(serviceData, null, 2)}`);
+      console.log(
+        `  Service Data      = ${JSON.stringify(serviceData, null, 2)}`
+      );
     }
 
     if (serviceUuids) {
@@ -81,7 +83,9 @@ const explore = async (peripheral) => {
 
       const descriptors = await characteristic.discoverDescriptorsAsync();
 
-      const userDescriptionDescriptor = descriptors.find((descriptor) => descriptor.uuid === '2901');
+      const userDescriptionDescriptor = descriptors.find(
+        (descriptor) => descriptor.uuid === '2901'
+      );
 
       if (userDescriptionDescriptor) {
         const data = await userDescriptionDescriptor.readValueAsync();
@@ -90,7 +94,9 @@ const explore = async (peripheral) => {
         }
       }
 
-      characteristicInfo += `\n    properties  ${characteristic.properties.join(', ')}`;
+      characteristicInfo += `\n    properties  ${characteristic.properties.join(
+        ', '
+      )}`;
 
       if (characteristic.properties.includes('read')) {
         const data = await characteristic.readAsync();
@@ -98,7 +104,9 @@ const explore = async (peripheral) => {
         if (data) {
           const string = data.toString('ascii');
 
-          characteristicInfo += `\n    value       ${data.toString('hex')} | '${string}'`;
+          characteristicInfo += `\n    value       ${data.toString(
+            'hex'
+          )} | '${string}'`;
         }
       }
 
@@ -108,3 +116,18 @@ const explore = async (peripheral) => {
 
   await peripheral.disconnectAsync();
 };
+
+process.on('SIGINT', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});
+
+process.on('SIGQUIT', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});
+
+process.on('SIGTERM', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});

--- a/examples/pizza/central.js
+++ b/examples/pizza/central.js
@@ -1,5 +1,5 @@
 /* eslint-disable handle-callback-err */
-const noble = require('../..');
+const noble = require('../..')({ extended: false });
 const pizza = require('./pizza');
 
 const pizzaServiceUuid = '13333333333333333333333333333337';
@@ -77,7 +77,9 @@ noble.on('discover', function (peripheral) {
 
             if (pizzaCrustCharacteristicUuid === characteristic.uuid) {
               pizzaCrustCharacteristic = characteristic;
-            } else if (pizzaToppingsCharacteristicUuid === characteristic.uuid) {
+            } else if (
+              pizzaToppingsCharacteristicUuid === characteristic.uuid
+            ) {
               pizzaToppingsCharacteristic = characteristic;
             } else if (pizzaBakeCharacteristicUuid === characteristic.uuid) {
               pizzaBakeCharacteristic = characteristic;
@@ -87,9 +89,11 @@ noble.on('discover', function (peripheral) {
           //
           // Check to see if we found all of our characteristics.
           //
-          if (pizzaCrustCharacteristic &&
-              pizzaToppingsCharacteristic &&
-              pizzaBakeCharacteristic) {
+          if (
+            pizzaCrustCharacteristic &&
+            pizzaToppingsCharacteristic &&
+            pizzaBakeCharacteristic
+          ) {
             //
             // We did, so bake a pizza!
             //
@@ -117,8 +121,8 @@ function bakePizza () {
       const toppings = Buffer.alloc(2);
       toppings.writeUInt16BE(
         pizza.PizzaToppings.EXTRA_CHEESE |
-        pizza.PizzaToppings.CANADIAN_BACON |
-        pizza.PizzaToppings.PINEAPPLE,
+          pizza.PizzaToppings.CANADIAN_BACON |
+          pizza.PizzaToppings.PINEAPPLE,
         0
       );
       pizzaToppingsCharacteristic.write(toppings, false, function (err) {
@@ -173,3 +177,18 @@ function bakePizza () {
     }
   });
 }
+
+process.on('SIGINT', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});
+
+process.on('SIGQUIT', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});
+
+process.on('SIGTERM', function () {
+  console.log('Caught interrupt signal');
+  noble.stopScanning(() => process.exit());
+});

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
-const Noble = require('./lib/noble');
-const bindings = require('./lib/resolve-bindings')();
+module.exports = function (options) {
+  const Noble = require('./lib/noble');
+  const bindings = require('./lib/resolve-bindings')(options);
 
-module.exports = new Noble(bindings);
+  return new Noble(bindings);
+};

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -13,6 +13,8 @@ const NobleBindings = function (options) {
   this._addresses = {};
   this._addresseTypes = {};
   this._connectable = {};
+  this._isExtended = 'extended' in options && options.extended;
+  this.scannable = {};
 
   this._pendingConnectionUuid = null;
   this._connectionQueue = [];
@@ -32,7 +34,10 @@ NobleBindings.prototype.setScanParameters = function (interval, window) {
   this._gap.setScanParameters(interval, window);
 };
 
-NobleBindings.prototype.startScanning = function (serviceUuids, allowDuplicates) {
+NobleBindings.prototype.startScanning = function (
+  serviceUuids,
+  allowDuplicates
+) {
   this._scanServiceUuids = serviceUuids || [];
 
   this._gap.startScanning(allowDuplicates);
@@ -61,7 +66,9 @@ NobleBindings.prototype.disconnect = function (peripheralUuid) {
 
 NobleBindings.prototype.cancelConnect = function (peripheralUuid) {
   // TODO: check if it was not in the queue and only then issue cancel on hci
-  this._connectionQueue = this._connectionQueue.filter(c => c.id !== peripheralUuid);
+  this._connectionQueue = this._connectionQueue.filter(
+    (c) => c.id !== peripheralUuid
+  );
   this._hci.cancelConnect(this._handles[peripheralUuid]);
 };
 
@@ -124,11 +131,19 @@ NobleBindings.prototype.onStateChange = function (state) {
   this._state = state;
 
   if (state === 'unauthorized') {
-    console.log('noble warning: adapter state unauthorized, please run as root or with sudo');
-    console.log('               or see README for information on running without root/sudo:');
-    console.log('               https://github.com/sandeepmistry/noble#running-on-linux');
+    console.log(
+      'noble warning: adapter state unauthorized, please run as root or with sudo'
+    );
+    console.log(
+      '               or see README for information on running without root/sudo:'
+    );
+    console.log(
+      '               https://github.com/sandeepmistry/noble#running-on-linux'
+    );
   } else if (state === 'unsupported') {
-    console.log('noble warning: adapter does not support Bluetooth Low Energy (BLE, Bluetooth Smart).');
+    console.log(
+      'noble warning: adapter does not support Bluetooth Low Energy (BLE, Bluetooth Smart).'
+    );
     console.log('               Try to run with environment variable:');
     console.log('               [sudo] NOBLE_HCI_DEVICE_ID=x node ...');
   }
@@ -152,14 +167,22 @@ NobleBindings.prototype.onScanStop = function () {
   this.emit('scanStop');
 };
 
-NobleBindings.prototype.onDiscover = function (status, address, addressType, connectable, advertisement, rssi) {
+NobleBindings.prototype.onDiscover = function (
+  status,
+  address,
+  addressType,
+  connectable,
+  advertisement,
+  rssi,
+  scannable
+) {
   if (this._scanServiceUuids === undefined) {
     return;
   }
 
   let serviceUuids = advertisement.serviceUuids || [];
   const serviceData = advertisement.serviceData || [];
-  let hasScanServiceUuids = (this._scanServiceUuids.length === 0);
+  let hasScanServiceUuids = this._scanServiceUuids.length === 0;
 
   if (!hasScanServiceUuids) {
     let i;
@@ -171,7 +194,8 @@ NobleBindings.prototype.onDiscover = function (status, address, addressType, con
     }
 
     for (i in serviceUuids) {
-      hasScanServiceUuids = (this._scanServiceUuids.indexOf(serviceUuids[i]) !== -1);
+      hasScanServiceUuids =
+        this._scanServiceUuids.indexOf(serviceUuids[i]) !== -1;
 
       if (hasScanServiceUuids) {
         break;
@@ -184,13 +208,33 @@ NobleBindings.prototype.onDiscover = function (status, address, addressType, con
     this._addresses[uuid] = address;
     this._addresseTypes[uuid] = addressType;
     this._connectable[uuid] = connectable;
+    this.scannable[uuid] = scannable;
 
-    this.emit('discover', uuid, address, addressType, connectable, advertisement, rssi);
+    this.emit(
+      'discover',
+      uuid,
+      address,
+      addressType,
+      connectable,
+      advertisement,
+      rssi,
+      scannable
+    );
   }
 };
 
-NobleBindings.prototype.onLeConnComplete = function (status, handle, role, addressType, address, interval, latency, supervisionTimeout, masterClockAccuracy) {
-  if (role !== 0) {
+NobleBindings.prototype.onLeConnComplete = function (
+  status,
+  handle,
+  role,
+  addressType,
+  address,
+  interval,
+  latency,
+  supervisionTimeout,
+  masterClockAccuracy
+) {
+  if (role !== 0 && role !== undefined) {
     // not master, ignore
     return;
   }
@@ -201,7 +245,14 @@ NobleBindings.prototype.onLeConnComplete = function (status, handle, role, addre
   if (status === 0) {
     uuid = address.split(':').join('').toLowerCase();
 
-    const aclStream = new AclStream(this._hci, handle, this._hci.addressType, this._hci.address, addressType, address);
+    const aclStream = new AclStream(
+      this._hci,
+      handle,
+      this._hci.addressType,
+      this._hci.address,
+      addressType,
+      address
+    );
     const gatt = new Gatt(address, aclStream);
     const signaling = new Signaling(handle, aclStream);
 
@@ -212,24 +263,45 @@ NobleBindings.prototype.onLeConnComplete = function (status, handle, role, addre
     this._handles[handle] = uuid;
 
     this._gatts[handle].on('mtu', this.onMtu.bind(this));
-    this._gatts[handle].on('servicesDiscover', this.onServicesDiscovered.bind(this));
-    this._gatts[handle].on('servicesDiscovered', this.onServicesDiscoveredEX.bind(this));
-    this._gatts[handle].on('includedServicesDiscover', this.onIncludedServicesDiscovered.bind(this));
-    this._gatts[handle].on('characteristicsDiscover', this.onCharacteristicsDiscovered.bind(this));
-    this._gatts[handle].on('characteristicsDiscovered', this.onCharacteristicsDiscoveredEX.bind(this));
+    this._gatts[handle].on(
+      'servicesDiscover',
+      this.onServicesDiscovered.bind(this)
+    );
+    this._gatts[handle].on(
+      'servicesDiscovered',
+      this.onServicesDiscoveredEX.bind(this)
+    );
+    this._gatts[handle].on(
+      'includedServicesDiscover',
+      this.onIncludedServicesDiscovered.bind(this)
+    );
+    this._gatts[handle].on(
+      'characteristicsDiscover',
+      this.onCharacteristicsDiscovered.bind(this)
+    );
+    this._gatts[handle].on(
+      'characteristicsDiscovered',
+      this.onCharacteristicsDiscoveredEX.bind(this)
+    );
     this._gatts[handle].on('read', this.onRead.bind(this));
     this._gatts[handle].on('write', this.onWrite.bind(this));
     this._gatts[handle].on('broadcast', this.onBroadcast.bind(this));
     this._gatts[handle].on('notify', this.onNotify.bind(this));
     this._gatts[handle].on('notification', this.onNotification.bind(this));
-    this._gatts[handle].on('descriptorsDiscover', this.onDescriptorsDiscovered.bind(this));
+    this._gatts[handle].on(
+      'descriptorsDiscover',
+      this.onDescriptorsDiscovered.bind(this)
+    );
     this._gatts[handle].on('valueRead', this.onValueRead.bind(this));
     this._gatts[handle].on('valueWrite', this.onValueWrite.bind(this));
     this._gatts[handle].on('handleRead', this.onHandleRead.bind(this));
     this._gatts[handle].on('handleWrite', this.onHandleWrite.bind(this));
     this._gatts[handle].on('handleNotify', this.onHandleNotify.bind(this));
 
-    this._signalings[handle].on('connectionParameterUpdateRequest', this.onConnectionParameterUpdateRequest.bind(this));
+    this._signalings[handle].on(
+      'connectionParameterUpdateRequest',
+      this.onConnectionParameterUpdateRequest.bind(this)
+    );
 
     this._gatts[handle].exchangeMtu(256);
   } else {
@@ -257,7 +329,12 @@ NobleBindings.prototype.onLeConnComplete = function (status, handle, role, addre
   }
 };
 
-NobleBindings.prototype.onLeConnUpdateComplete = function (handle, interval, latency, supervisionTimeout) {
+NobleBindings.prototype.onLeConnUpdateComplete = function (
+  handle,
+  interval,
+  latency,
+  supervisionTimeout
+) {
   // no-op
 };
 
@@ -331,7 +408,10 @@ NobleBindings.prototype.discoverServices = function (peripheralUuid, uuids) {
   }
 };
 
-NobleBindings.prototype.onServicesDiscovered = function (address, serviceUuids) {
+NobleBindings.prototype.onServicesDiscovered = function (
+  address,
+  serviceUuids
+) {
   const uuid = address.split(':').join('').toLowerCase();
 
   this.emit('servicesDiscover', uuid, serviceUuids);
@@ -343,7 +423,11 @@ NobleBindings.prototype.onServicesDiscoveredEX = function (address, services) {
   this.emit('servicesDiscovered', uuid, services);
 };
 
-NobleBindings.prototype.discoverIncludedServices = function (peripheralUuid, serviceUuid, serviceUuids) {
+NobleBindings.prototype.discoverIncludedServices = function (
+  peripheralUuid,
+  serviceUuid,
+  serviceUuids
+) {
   const handle = this._handles[peripheralUuid];
   const gatt = this._gatts[handle];
 
@@ -354,13 +438,26 @@ NobleBindings.prototype.discoverIncludedServices = function (peripheralUuid, ser
   }
 };
 
-NobleBindings.prototype.onIncludedServicesDiscovered = function (address, serviceUuid, includedServiceUuids) {
+NobleBindings.prototype.onIncludedServicesDiscovered = function (
+  address,
+  serviceUuid,
+  includedServiceUuids
+) {
   const uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('includedServicesDiscover', uuid, serviceUuid, includedServiceUuids);
+  this.emit(
+    'includedServicesDiscover',
+    uuid,
+    serviceUuid,
+    includedServiceUuids
+  );
 };
 
-NobleBindings.prototype.addCharacteristics = function (peripheralUuid, serviceUuid, characteristics) {
+NobleBindings.prototype.addCharacteristics = function (
+  peripheralUuid,
+  serviceUuid,
+  characteristics
+) {
   const handle = this._handles[peripheralUuid];
   const gatt = this._gatts[handle];
 
@@ -371,7 +468,11 @@ NobleBindings.prototype.addCharacteristics = function (peripheralUuid, serviceUu
   }
 };
 
-NobleBindings.prototype.discoverCharacteristics = function (peripheralUuid, serviceUuid, characteristicUuids) {
+NobleBindings.prototype.discoverCharacteristics = function (
+  peripheralUuid,
+  serviceUuid,
+  characteristicUuids
+) {
   const handle = this._handles[peripheralUuid];
   const gatt = this._gatts[handle];
 
@@ -382,19 +483,31 @@ NobleBindings.prototype.discoverCharacteristics = function (peripheralUuid, serv
   }
 };
 
-NobleBindings.prototype.onCharacteristicsDiscovered = function (address, serviceUuid, characteristics) {
+NobleBindings.prototype.onCharacteristicsDiscovered = function (
+  address,
+  serviceUuid,
+  characteristics
+) {
   const uuid = address.split(':').join('').toLowerCase();
 
   this.emit('characteristicsDiscover', uuid, serviceUuid, characteristics);
 };
 
-NobleBindings.prototype.onCharacteristicsDiscoveredEX = function (address, serviceUuid, characteristics) {
+NobleBindings.prototype.onCharacteristicsDiscoveredEX = function (
+  address,
+  serviceUuid,
+  characteristics
+) {
   const uuid = address.split(':').join('').toLowerCase();
 
   this.emit('characteristicsDiscovered', uuid, serviceUuid, characteristics);
 };
 
-NobleBindings.prototype.read = function (peripheralUuid, serviceUuid, characteristicUuid) {
+NobleBindings.prototype.read = function (
+  peripheralUuid,
+  serviceUuid,
+  characteristicUuid
+) {
   const handle = this._handles[peripheralUuid];
   const gatt = this._gatts[handle];
 
@@ -405,13 +518,24 @@ NobleBindings.prototype.read = function (peripheralUuid, serviceUuid, characteri
   }
 };
 
-NobleBindings.prototype.onRead = function (address, serviceUuid, characteristicUuid, data) {
+NobleBindings.prototype.onRead = function (
+  address,
+  serviceUuid,
+  characteristicUuid,
+  data
+) {
   const uuid = address.split(':').join('').toLowerCase();
 
   this.emit('read', uuid, serviceUuid, characteristicUuid, data, false);
 };
 
-NobleBindings.prototype.write = function (peripheralUuid, serviceUuid, characteristicUuid, data, withoutResponse) {
+NobleBindings.prototype.write = function (
+  peripheralUuid,
+  serviceUuid,
+  characteristicUuid,
+  data,
+  withoutResponse
+) {
   const handle = this._handles[peripheralUuid];
   const gatt = this._gatts[handle];
 
@@ -422,13 +546,22 @@ NobleBindings.prototype.write = function (peripheralUuid, serviceUuid, character
   }
 };
 
-NobleBindings.prototype.onWrite = function (address, serviceUuid, characteristicUuid) {
+NobleBindings.prototype.onWrite = function (
+  address,
+  serviceUuid,
+  characteristicUuid
+) {
   const uuid = address.split(':').join('').toLowerCase();
 
   this.emit('write', uuid, serviceUuid, characteristicUuid);
 };
 
-NobleBindings.prototype.broadcast = function (peripheralUuid, serviceUuid, characteristicUuid, broadcast) {
+NobleBindings.prototype.broadcast = function (
+  peripheralUuid,
+  serviceUuid,
+  characteristicUuid,
+  broadcast
+) {
   const handle = this._handles[peripheralUuid];
   const gatt = this._gatts[handle];
 
@@ -439,13 +572,23 @@ NobleBindings.prototype.broadcast = function (peripheralUuid, serviceUuid, chara
   }
 };
 
-NobleBindings.prototype.onBroadcast = function (address, serviceUuid, characteristicUuid, state) {
+NobleBindings.prototype.onBroadcast = function (
+  address,
+  serviceUuid,
+  characteristicUuid,
+  state
+) {
   const uuid = address.split(':').join('').toLowerCase();
 
   this.emit('broadcast', uuid, serviceUuid, characteristicUuid, state);
 };
 
-NobleBindings.prototype.notify = function (peripheralUuid, serviceUuid, characteristicUuid, notify) {
+NobleBindings.prototype.notify = function (
+  peripheralUuid,
+  serviceUuid,
+  characteristicUuid,
+  notify
+) {
   const handle = this._handles[peripheralUuid];
   const gatt = this._gatts[handle];
 
@@ -456,19 +599,33 @@ NobleBindings.prototype.notify = function (peripheralUuid, serviceUuid, characte
   }
 };
 
-NobleBindings.prototype.onNotify = function (address, serviceUuid, characteristicUuid, state) {
+NobleBindings.prototype.onNotify = function (
+  address,
+  serviceUuid,
+  characteristicUuid,
+  state
+) {
   const uuid = address.split(':').join('').toLowerCase();
 
   this.emit('notify', uuid, serviceUuid, characteristicUuid, state);
 };
 
-NobleBindings.prototype.onNotification = function (address, serviceUuid, characteristicUuid, data) {
+NobleBindings.prototype.onNotification = function (
+  address,
+  serviceUuid,
+  characteristicUuid,
+  data
+) {
   const uuid = address.split(':').join('').toLowerCase();
 
   this.emit('read', uuid, serviceUuid, characteristicUuid, data, true);
 };
 
-NobleBindings.prototype.discoverDescriptors = function (peripheralUuid, serviceUuid, characteristicUuid) {
+NobleBindings.prototype.discoverDescriptors = function (
+  peripheralUuid,
+  serviceUuid,
+  characteristicUuid
+) {
   const handle = this._handles[peripheralUuid];
   const gatt = this._gatts[handle];
 
@@ -479,13 +636,29 @@ NobleBindings.prototype.discoverDescriptors = function (peripheralUuid, serviceU
   }
 };
 
-NobleBindings.prototype.onDescriptorsDiscovered = function (address, serviceUuid, characteristicUuid, descriptorUuids) {
+NobleBindings.prototype.onDescriptorsDiscovered = function (
+  address,
+  serviceUuid,
+  characteristicUuid,
+  descriptorUuids
+) {
   const uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('descriptorsDiscover', uuid, serviceUuid, characteristicUuid, descriptorUuids);
+  this.emit(
+    'descriptorsDiscover',
+    uuid,
+    serviceUuid,
+    characteristicUuid,
+    descriptorUuids
+  );
 };
 
-NobleBindings.prototype.readValue = function (peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid) {
+NobleBindings.prototype.readValue = function (
+  peripheralUuid,
+  serviceUuid,
+  characteristicUuid,
+  descriptorUuid
+) {
   const handle = this._handles[peripheralUuid];
   const gatt = this._gatts[handle];
 
@@ -496,13 +669,32 @@ NobleBindings.prototype.readValue = function (peripheralUuid, serviceUuid, chara
   }
 };
 
-NobleBindings.prototype.onValueRead = function (address, serviceUuid, characteristicUuid, descriptorUuid, data) {
+NobleBindings.prototype.onValueRead = function (
+  address,
+  serviceUuid,
+  characteristicUuid,
+  descriptorUuid,
+  data
+) {
   const uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('valueRead', uuid, serviceUuid, characteristicUuid, descriptorUuid, data);
+  this.emit(
+    'valueRead',
+    uuid,
+    serviceUuid,
+    characteristicUuid,
+    descriptorUuid,
+    data
+  );
 };
 
-NobleBindings.prototype.writeValue = function (peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data) {
+NobleBindings.prototype.writeValue = function (
+  peripheralUuid,
+  serviceUuid,
+  characteristicUuid,
+  descriptorUuid,
+  data
+) {
   const handle = this._handles[peripheralUuid];
   const gatt = this._gatts[handle];
 
@@ -513,10 +705,21 @@ NobleBindings.prototype.writeValue = function (peripheralUuid, serviceUuid, char
   }
 };
 
-NobleBindings.prototype.onValueWrite = function (address, serviceUuid, characteristicUuid, descriptorUuid) {
+NobleBindings.prototype.onValueWrite = function (
+  address,
+  serviceUuid,
+  characteristicUuid,
+  descriptorUuid
+) {
   const uuid = address.split(':').join('').toLowerCase();
 
-  this.emit('valueWrite', uuid, serviceUuid, characteristicUuid, descriptorUuid);
+  this.emit(
+    'valueWrite',
+    uuid,
+    serviceUuid,
+    characteristicUuid,
+    descriptorUuid
+  );
 };
 
 NobleBindings.prototype.readHandle = function (peripheralUuid, attHandle) {
@@ -536,7 +739,12 @@ NobleBindings.prototype.onHandleRead = function (address, handle, data) {
   this.emit('handleRead', uuid, handle, data);
 };
 
-NobleBindings.prototype.writeHandle = function (peripheralUuid, attHandle, data, withoutResponse) {
+NobleBindings.prototype.writeHandle = function (
+  peripheralUuid,
+  attHandle,
+  data,
+  withoutResponse
+) {
   const handle = this._handles[peripheralUuid];
   const gatt = this._gatts[handle];
 
@@ -559,8 +767,20 @@ NobleBindings.prototype.onHandleNotify = function (address, handle, data) {
   this.emit('handleNotify', uuid, handle, data);
 };
 
-NobleBindings.prototype.onConnectionParameterUpdateRequest = function (handle, minInterval, maxInterval, latency, supervisionTimeout) {
-  this._hci.connUpdateLe(handle, minInterval, maxInterval, latency, supervisionTimeout);
+NobleBindings.prototype.onConnectionParameterUpdateRequest = function (
+  handle,
+  minInterval,
+  maxInterval,
+  latency,
+  supervisionTimeout
+) {
+  this._hci.connUpdateLe(
+    handle,
+    minInterval,
+    maxInterval,
+    latency,
+    supervisionTimeout
+  );
 };
 
 module.exports = NobleBindings;

--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -4,7 +4,16 @@ const events = require('events');
 const os = require('os');
 const util = require('util');
 
-const isChip = (os.platform() === 'linux') && (os.release().indexOf('-ntc') !== -1);
+const isChip = os.platform() === 'linux' && os.release().indexOf('-ntc') !== -1;
+
+const LE_META_EVENT_TYPE_CONNECTABLE = 0x3;
+const LE_META_EVENT_TYPE_SCAN_RESPONSE = 0x4;
+const LE_META_EVENT_TYPE_SCANNABLE = 0x6;
+
+const LE_META_EXTENDED_EVENT_TYPE_CONNECTABLE_MASK = 0x1;
+const LE_META_EXTENDED_EVENT_TYPE_SCANNABLE_MASK = 0x2;
+const LE_META_EXTENDED_EVENT_TYPE_SCAN_RESPONSE_MASK = 0x8;
+const LE_META_EXTENDED_EVENT_TYPE_INCOMPLETE_MASK = 0x20;
 
 const Gap = function (hci) {
   this._hci = hci;
@@ -17,6 +26,10 @@ const Gap = function (hci) {
   this._hci.on('leScanParametersSet', this.onHciLeScanParametersSet.bind(this));
   this._hci.on('leScanEnableSet', this.onHciLeScanEnableSet.bind(this));
   this._hci.on('leAdvertisingReport', this.onHciLeAdvertisingReport.bind(this));
+  this._hci.on(
+    'leExtendedAdvertisingReport',
+    this.onHciLeExtendedAdvertisingReport.bind(this)
+  );
 
   this._hci.on('leScanEnableSetCmd', this.onLeScanEnableSetCmd.bind(this));
 };
@@ -85,7 +98,7 @@ Gap.prototype.onLeScanEnableSetCmd = function (enable, filterDuplicates) {
   // If we are scanning, then a change happens if the new command stops
   // scanning or if duplicate filtering changes.
   // If we are not scanning, then a change happens if scanning was enabled.
-  if ((this._scanState === 'starting' || this._scanState === 'started')) {
+  if (this._scanState === 'starting' || this._scanState === 'started') {
     if (!enable) {
       this.emit('scanStop');
     } else if (this._scanFilterDuplicates !== filterDuplicates) {
@@ -93,42 +106,181 @@ Gap.prototype.onLeScanEnableSetCmd = function (enable, filterDuplicates) {
 
       this.emit('scanStart', this._scanFilterDuplicates);
     }
-  } else if ((this._scanState === 'stopping' || this._scanState === 'stopped') && enable) {
+  } else if (
+    (this._scanState === 'stopping' || this._scanState === 'stopped') &&
+    enable
+  ) {
     // Someone started scanning on us.
     this.emit('scanStart', this._scanFilterDuplicates);
   }
 };
 
-Gap.prototype.onHciLeAdvertisingReport = function (status, type, address, addressType, eir, rssi) {
+Gap.prototype.onHciLeAdvertisingReport = function (
+  status,
+  type,
+  address,
+  addressType,
+  eir,
+  rssi
+) {
   const previouslyDiscovered = !!this._discoveries[address];
+
+  let discoveryCount = previouslyDiscovered
+    ? this._discoveries[address].count
+    : 0;
+  let hasScanResponse = previouslyDiscovered
+    ? this._discoveries[address].hasScanResponse
+    : false;
+
+  if (type === LE_META_EVENT_TYPE_SCAN_RESPONSE) {
+    hasScanResponse = true;
+  }
+
+  discoveryCount++;
+
+  const advertisement = this.parseServices(
+    address,
+    eir,
+    previouslyDiscovered,
+    hasScanResponse
+  );
+
+  debug(`advertisement = ${JSON.stringify(advertisement, null, 0)}`);
+
+  const connectable =
+    type === LE_META_EVENT_TYPE_SCAN_RESPONSE && previouslyDiscovered
+      ? this._discoveries[address].connectable
+      : type !== LE_META_EVENT_TYPE_CONNECTABLE;
+  const scannable = type === LE_META_EVENT_TYPE_SCANNABLE;
+
+  this._discoveries[address] = {
+    address: address,
+    addressType: addressType,
+    connectable: connectable,
+    advertisement: advertisement,
+    rssi: rssi,
+    count: discoveryCount,
+    hasScanResponse: hasScanResponse
+  };
+
+  // only report after a scan response event or if non-connectable or more than one discovery without a scan response, so more data can be collected
+  if (
+    type === LE_META_EVENT_TYPE_SCAN_RESPONSE ||
+    !connectable ||
+    (discoveryCount > 1 && !hasScanResponse) ||
+    process.env.NOBLE_REPORT_ALL_HCI_EVENTS
+  ) {
+    this.emit(
+      'discover',
+      status,
+      address,
+      addressType,
+      connectable,
+      advertisement,
+      rssi,
+      scannable
+    );
+  }
+};
+
+Gap.prototype.onHciLeExtendedAdvertisingReport = function (
+  status,
+  type,
+  address,
+  addressType,
+  txpower,
+  rssi,
+  eir
+) {
+  const previouslyDiscovered = !!this._discoveries[address];
+
+  let discoveryCount = previouslyDiscovered
+    ? this._discoveries[address].count
+    : 0;
+  let hasScanResponse = previouslyDiscovered
+    ? this._discoveries[address].hasScanResponse
+    : false;
+
+  if (type & LE_META_EXTENDED_EVENT_TYPE_SCAN_RESPONSE_MASK) {
+    hasScanResponse = true;
+  }
+
+  discoveryCount++;
+
+  const advertisement = this.parseServices(
+    address,
+    eir,
+    previouslyDiscovered,
+    hasScanResponse,
+    txpower
+  );
+
+  debug(`advertisement = ${JSON.stringify(advertisement, null, 0)}`);
+
+  const connectable =
+    type & 0x8 && previouslyDiscovered
+      ? this._discoveries[address].connectable
+      : type & LE_META_EXTENDED_EVENT_TYPE_CONNECTABLE_MASK;
+  const scannable = type & LE_META_EXTENDED_EVENT_TYPE_SCANNABLE_MASK ? 1 : 0;
+  const incomplete = type & LE_META_EXTENDED_EVENT_TYPE_INCOMPLETE_MASK ? 1 : 0;
+
+  this._discoveries[address] = {
+    address: address,
+    addressType: addressType,
+    connectable: connectable,
+    advertisement: advertisement,
+    rssi: rssi,
+    count: discoveryCount,
+    hasScanResponse: hasScanResponse
+  };
+
+  // only report after a scan response event or if non-connectable or more than one discovery without a scan response, so more data can be collected
+  if (
+    type & LE_META_EXTENDED_EVENT_TYPE_SCAN_RESPONSE_MASK ||
+    (!connectable && !incomplete) ||
+    (discoveryCount > 1 && !hasScanResponse) ||
+    process.env.NOBLE_REPORT_ALL_HCI_EVENTS
+  ) {
+    this.emit(
+      'discover',
+      status,
+      address,
+      addressType,
+      connectable,
+      advertisement,
+      rssi,
+      scannable
+    );
+  }
+};
+
+Gap.prototype.parseServices = function (
+  address,
+  eir,
+  previouslyDiscovered,
+  hasScanResponse,
+  txpower
+) {
+  let i = 0;
   const advertisement = previouslyDiscovered
     ? this._discoveries[address].advertisement
     : {
         localName: undefined,
-        txPowerLevel: undefined,
+        txPowerLevel: txpower,
         manufacturerData: undefined,
         serviceData: [],
         serviceUuids: [],
         solicitationServiceUuids: []
       };
 
-  let discoveryCount = previouslyDiscovered ? this._discoveries[address].count : 0;
-  let hasScanResponse = previouslyDiscovered ? this._discoveries[address].hasScanResponse : false;
-
-  if (type === 0x04) {
-    hasScanResponse = true;
-  } else {
+  if (!hasScanResponse) {
     // reset service data every non-scan response event
     advertisement.serviceData = [];
     advertisement.serviceUuids = [];
     advertisement.serviceSolicitationUuids = [];
   }
 
-  discoveryCount++;
-
-  let i = 0;
-
-  while ((i + 1) < eir.length) {
+  while (i + 1 < eir.length) {
     const length = eir.readUInt8(i);
 
     if (length < 1) {
@@ -138,7 +290,7 @@ Gap.prototype.onHciLeAdvertisingReport = function (status, type, address, addres
 
     const eirType = eir.readUInt8(i + 1); // https://www.bluetooth.org/en-us/specification/assigned-numbers/generic-access-profile
 
-    if ((i + length + 1) > eir.length) {
+    if (i + length + 1 > eir.length) {
       debug('invalid EIR data, out of range of buffer length');
       break;
     }
@@ -159,7 +311,12 @@ Gap.prototype.onHciLeAdvertisingReport = function (status, type, address, addres
       case 0x06: // Incomplete List of 128-bit Service Class UUIDs
       case 0x07: // Complete List of 128-bit Service Class UUIDs
         for (let j = 0; j < bytes.length - 15; j += 16) {
-          const serviceUuid = bytes.slice(j, j + 16).toString('hex').match(/.{1,2}/g).reverse().join('');
+          const serviceUuid = bytes
+            .slice(j, j + 16)
+            .toString('hex')
+            .match(/.{1,2}/g)
+            .reverse()
+            .join('');
           if (advertisement.serviceUuids.indexOf(serviceUuid) === -1) {
             advertisement.serviceUuids.push(serviceUuid);
           }
@@ -178,38 +335,70 @@ Gap.prototype.onHciLeAdvertisingReport = function (status, type, address, addres
       case 0x14: // List of 16 bit solicitation UUIDs
         for (let j = 0; j < bytes.length - 1; j += 2) {
           const serviceSolicitationUuid = bytes.readUInt16LE(j).toString(16);
-          if (advertisement.serviceSolicitationUuids.indexOf(serviceSolicitationUuid) === -1) {
-            advertisement.serviceSolicitationUuids.push(serviceSolicitationUuid);
+          if (
+            advertisement.serviceSolicitationUuids.indexOf(
+              serviceSolicitationUuid
+            ) === -1
+          ) {
+            advertisement.serviceSolicitationUuids.push(
+              serviceSolicitationUuid
+            );
           }
         }
         break;
 
       case 0x15: // List of 128 bit solicitation UUIDs
         for (let j = 0; j < bytes.length - 15; j += 16) {
-          const serviceSolicitationUuid = bytes.slice(j, j + 16).toString('hex').match(/.{1,2}/g).reverse().join('');
-          if (advertisement.serviceSolicitationUuids.indexOf(serviceSolicitationUuid) === -1) {
-            advertisement.serviceSolicitationUuids.push(serviceSolicitationUuid);
+          const serviceSolicitationUuid = bytes
+            .slice(j, j + 16)
+            .toString('hex')
+            .match(/.{1,2}/g)
+            .reverse()
+            .join('');
+          if (
+            advertisement.serviceSolicitationUuids.indexOf(
+              serviceSolicitationUuid
+            ) === -1
+          ) {
+            advertisement.serviceSolicitationUuids.push(
+              serviceSolicitationUuid
+            );
           }
         }
         break;
 
       case 0x16: // 16-bit Service Data, there can be multiple occurences
         advertisement.serviceData.push({
-          uuid: bytes.slice(0, 2).toString('hex').match(/.{1,2}/g).reverse().join(''),
+          uuid: bytes
+            .slice(0, 2)
+            .toString('hex')
+            .match(/.{1,2}/g)
+            .reverse()
+            .join(''),
           data: bytes.slice(2, bytes.length)
         });
         break;
 
       case 0x20: // 32-bit Service Data, there can be multiple occurences
         advertisement.serviceData.push({
-          uuid: bytes.slice(0, 4).toString('hex').match(/.{1,2}/g).reverse().join(''),
+          uuid: bytes
+            .slice(0, 4)
+            .toString('hex')
+            .match(/.{1,2}/g)
+            .reverse()
+            .join(''),
           data: bytes.slice(4, bytes.length)
         });
         break;
 
       case 0x21: // 128-bit Service Data, there can be multiple occurences
         advertisement.serviceData.push({
-          uuid: bytes.slice(0, 16).toString('hex').match(/.{1,2}/g).reverse().join(''),
+          uuid: bytes
+            .slice(0, 16)
+            .toString('hex')
+            .match(/.{1,2}/g)
+            .reverse()
+            .join(''),
           data: bytes.slice(16, bytes.length)
         });
         break;
@@ -217,8 +406,14 @@ Gap.prototype.onHciLeAdvertisingReport = function (status, type, address, addres
       case 0x1f: // List of 32 bit solicitation UUIDs
         for (let j = 0; j < bytes.length - 3; j += 4) {
           const serviceSolicitationUuid = bytes.readUInt32LE(j).toString(16);
-          if (advertisement.serviceSolicitationUuids.indexOf(serviceSolicitationUuid) === -1) {
-            advertisement.serviceSolicitationUuids.push(serviceSolicitationUuid);
+          if (
+            advertisement.serviceSolicitationUuids.indexOf(
+              serviceSolicitationUuid
+            ) === -1
+          ) {
+            advertisement.serviceSolicitationUuids.push(
+              serviceSolicitationUuid
+            );
           }
         }
         break;
@@ -228,27 +423,10 @@ Gap.prototype.onHciLeAdvertisingReport = function (status, type, address, addres
         break;
     }
 
-    i += (length + 1);
+    i += length + 1;
   }
 
-  debug(`advertisement = ${JSON.stringify(advertisement, null, 0)}`);
-
-  const connectable = (type === 0x04 && previouslyDiscovered) ? this._discoveries[address].connectable : (type !== 0x03);
-
-  this._discoveries[address] = {
-    address: address,
-    addressType: addressType,
-    connectable: connectable,
-    advertisement: advertisement,
-    rssi: rssi,
-    count: discoveryCount,
-    hasScanResponse: hasScanResponse
-  };
-
-  // only report after a scan response event or if non-connectable or more than one discovery without a scan response, so more data can be collected
-  if (type === 0x04 || !connectable || (discoveryCount > 1 && !hasScanResponse) || process.env.NOBLE_REPORT_ALL_HCI_EVENTS) {
-    this.emit('discover', status, address, addressType, connectable, advertisement, rssi);
-  }
+  return advertisement;
 };
 
 module.exports = Gap;

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -89,7 +89,7 @@ Gatt.prototype.onAclStreamData = function (cid, data) {
     return;
   }
 
-  if (this._currentCommand && data.toString('hex') === this._currentCommand.buffer.toString('hex')) {
+  if (this._currentCommand && (data.toString('hex') === this._currentCommand.buffer.toString('hex'))) {
     debug(`${this._address}: echo ... echo ... echo ...`);
   } else if (data[0] % 2 === 0) {
     if (process.env.NOBLE_MULTI_ROLE) {
@@ -125,6 +125,11 @@ Gatt.prototype.onAclStreamData = function (cid, data) {
         (data[4] === ATT_ECODE_AUTHENTICATION || data[4] === ATT_ECODE_AUTHORIZATION || data[4] === ATT_ECODE_INSUFF_ENC) &&
         this._security !== 'medium') {
       this._aclStream.encrypt();
+      return;
+    }
+
+    if (data[0] === ATT_OP_ERROR && data[4] === ATT_ECODE_INVALID_PDU) {
+      debug('Error: can\'t change MTU, invalid PDU');
       return;
     }
 
@@ -355,7 +360,7 @@ Gatt.prototype.discoverServices = function (uuids) {
       }
     }
 
-    if (opcode !== ATT_OP_READ_BY_GROUP_RESP || services[services.length - 1].endHandle === 0xffff) {
+    if ((opcode !== ATT_OP_READ_BY_GROUP_RESP && opcode !== ATT_OP_ERROR) || services[services.length - 1].endHandle === 0xffff) {
       const serviceUuids = [];
       for (i = 0; i < services.length; i++) {
         const uuid = services[i].uuid.trim();

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -22,6 +22,8 @@ const EVT_LE_META_EVENT = 0x3e;
 
 const EVT_LE_CONN_COMPLETE = 0x01;
 const EVT_LE_ADVERTISING_REPORT = 0x02;
+const EVT_LE_ENHANCED_CONN_COMPLETE = 0x0a;
+const EVT_LE_EXTENDED_ADVERTISING_REPORT = 0x0d;
 const EVT_LE_CONN_UPDATE_COMPLETE = 0x03;
 
 const OGF_LINK_CTL = 0x01;
@@ -30,11 +32,14 @@ const OCF_DISCONNECT = 0x0006;
 const OGF_HOST_CTL = 0x03;
 const OCF_SET_EVENT_MASK = 0x0001;
 const OCF_RESET = 0x0003;
-const OCF_READ_LE_HOST_SUPPORTED = 0x006C;
-const OCF_WRITE_LE_HOST_SUPPORTED = 0x006D;
+const OCF_SET_RANDOM_MAC = 0x0005;
+const OCF_SET_PHY = 0x0031;
+const OCF_READ_LE_HOST_SUPPORTED = 0x006c;
+const OCF_WRITE_LE_HOST_SUPPORTED = 0x006d;
 
 const OGF_INFO_PARAM = 0x04;
 const OCF_READ_LOCAL_VERSION = 0x0001;
+const OCF_READ_SUPPORTED_COMMANDS = 0x0002;
 const OCF_READ_BUFFER_SIZE = 0x0005;
 const OCF_READ_BD_ADDR = 0x0009;
 
@@ -44,33 +49,47 @@ const OCF_READ_RSSI = 0x0005;
 const OGF_LE_CTL = 0x08;
 const OCF_LE_SET_EVENT_MASK = 0x0001;
 const OCF_LE_READ_BUFFER_SIZE = 0x0002;
+const OCF_LE_SET_EXTENDED_SCAN_PARAMETERS = 0x0041;
+const OCF_LE_SET_EXTENDED_SCAN_ENABLE = 0x0042;
 const OCF_LE_SET_SCAN_PARAMETERS = 0x000b;
 const OCF_LE_SET_SCAN_ENABLE = 0x000c;
 const OCF_LE_CREATE_CONN = 0x000d;
+const OCF_LE_CREATE_EXTENDED_CONN = 0x0043;
 const OCF_LE_CANCEL_CONN = 0x000e;
 const OCF_LE_CONN_UPDATE = 0x0013;
 const OCF_LE_START_ENCRYPTION = 0x0019;
-const DISCONNECT_CMD = OCF_DISCONNECT | OGF_LINK_CTL << 10;
+const DISCONNECT_CMD = OCF_DISCONNECT | (OGF_LINK_CTL << 10);
 
-const SET_EVENT_MASK_CMD = OCF_SET_EVENT_MASK | OGF_HOST_CTL << 10;
-const RESET_CMD = OCF_RESET | OGF_HOST_CTL << 10;
-const READ_LE_HOST_SUPPORTED_CMD = OCF_READ_LE_HOST_SUPPORTED | OGF_HOST_CTL << 10;
-const WRITE_LE_HOST_SUPPORTED_CMD = OCF_WRITE_LE_HOST_SUPPORTED | OGF_HOST_CTL << 10;
+const SET_EVENT_MASK_CMD = OCF_SET_EVENT_MASK | (OGF_HOST_CTL << 10);
+const RESET_CMD = OCF_RESET | (OGF_HOST_CTL << 10);
+const READ_LE_HOST_SUPPORTED_CMD =
+  OCF_READ_LE_HOST_SUPPORTED | (OGF_HOST_CTL << 10);
+const WRITE_LE_HOST_SUPPORTED_CMD =
+  OCF_WRITE_LE_HOST_SUPPORTED | (OGF_HOST_CTL << 10);
 
 const READ_LOCAL_VERSION_CMD = OCF_READ_LOCAL_VERSION | (OGF_INFO_PARAM << 10);
+const READ_SUPPORTED_COMMANDS_CMD =
+  OCF_READ_SUPPORTED_COMMANDS | (OGF_INFO_PARAM << 10);
 const READ_BUFFER_SIZE_CMD = OCF_READ_BUFFER_SIZE | (OGF_INFO_PARAM << 10);
 const READ_BD_ADDR_CMD = OCF_READ_BD_ADDR | (OGF_INFO_PARAM << 10);
 
-const READ_RSSI_CMD = OCF_READ_RSSI | OGF_STATUS_PARAM << 10;
+const READ_RSSI_CMD = OCF_READ_RSSI | (OGF_STATUS_PARAM << 10);
 
-const LE_SET_EVENT_MASK_CMD = OCF_LE_SET_EVENT_MASK | OGF_LE_CTL << 10;
-const LE_READ_BUFFER_SIZE_CMD = OCF_LE_READ_BUFFER_SIZE | OGF_LE_CTL << 10;
-const LE_SET_SCAN_PARAMETERS_CMD = OCF_LE_SET_SCAN_PARAMETERS | OGF_LE_CTL << 10;
-const LE_SET_SCAN_ENABLE_CMD = OCF_LE_SET_SCAN_ENABLE | OGF_LE_CTL << 10;
-const LE_CREATE_CONN_CMD = OCF_LE_CREATE_CONN | OGF_LE_CTL << 10;
-const LE_CONN_UPDATE_CMD = OCF_LE_CONN_UPDATE | OGF_LE_CTL << 10;
-const LE_CANCEL_CONN_CMD = OCF_LE_CANCEL_CONN | OGF_LE_CTL << 10;
-const LE_START_ENCRYPTION_CMD = OCF_LE_START_ENCRYPTION | OGF_LE_CTL << 10;
+const LE_SET_EVENT_MASK_CMD = OCF_LE_SET_EVENT_MASK | (OGF_LE_CTL << 10);
+const LE_READ_BUFFER_SIZE_CMD = OCF_LE_READ_BUFFER_SIZE | (OGF_LE_CTL << 10);
+const LE_SET_EXTENDED_SCAN_PARAMETERS_CMD =
+  OCF_LE_SET_EXTENDED_SCAN_PARAMETERS | (OGF_LE_CTL << 10);
+const LE_SET_EXTENDED_SCAN_ENABLE_CMD =
+  OCF_LE_SET_EXTENDED_SCAN_ENABLE | (OGF_LE_CTL << 10);
+const LE_SET_SCAN_PARAMETERS_CMD =
+  OCF_LE_SET_SCAN_PARAMETERS | (OGF_LE_CTL << 10);
+const LE_SET_SCAN_ENABLE_CMD = OCF_LE_SET_SCAN_ENABLE | (OGF_LE_CTL << 10);
+const LE_CREATE_CONN_CMD = OCF_LE_CREATE_CONN | (OGF_LE_CTL << 10);
+const LE_CREATE_EXTENDED_CONN_CMD =
+  OCF_LE_CREATE_EXTENDED_CONN | (OGF_LE_CTL << 10);
+const LE_CONN_UPDATE_CMD = OCF_LE_CONN_UPDATE | (OGF_LE_CTL << 10);
+const LE_CANCEL_CONN_CMD = OCF_LE_CANCEL_CONN | (OGF_LE_CTL << 10);
+const LE_START_ENCRYPTION_CMD = OCF_LE_START_ENCRYPTION | (OGF_LE_CTL << 10);
 const HCI_OE_USER_ENDED_CONNECTION = 0x13;
 
 const STATUS_MAPPER = require('./hci-status');
@@ -79,6 +98,7 @@ const Hci = function (options) {
   options = options || {};
   this._socket = new BluetoothHciSocket();
   this._isDevUp = null;
+  this._isExtended = 'extended' in options && options.extended;
   this._state = null;
 
   this._handleBuffers = {};
@@ -98,7 +118,9 @@ const Hci = function (options) {
       ? parseInt(process.env.NOBLE_HCI_DEVICE_ID, 10)
       : undefined;
 
-  this._userChannel = (typeof options.userChannel === 'undefined' && options.userChannel) || process.env.HCI_CHANNEL_USER;
+  this._userChannel =
+    (typeof options.userChannel === 'undefined' && options.userChannel) ||
+    process.env.HCI_CHANNEL_USER;
 
   this.on('stateChange', this.onStateChange.bind(this));
 };
@@ -138,6 +160,10 @@ Hci.prototype.pollIsDevUp = function () {
         this.init();
         return;
       }
+
+      if (this._isExtended) {
+        this.setCodedPhySupport();
+      }
       this.setSocketFilter();
       this.setEventMask();
       this.setLeEventMask();
@@ -156,11 +182,58 @@ Hci.prototype.pollIsDevUp = function () {
   setTimeout(this.pollIsDevUp.bind(this), 1000);
 };
 
+Hci.prototype.setCodedPhySupport = function () {
+  const cmd = Buffer.alloc(7);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(OCF_SET_PHY | (OGF_LE_CTL << 10), 1);
+
+  // length
+  cmd.writeUInt8(0x03, 3);
+
+  // data
+  cmd.writeUInt8(0x00, 4); // all phy prefs
+  cmd.writeUInt8(0x05, 5); // tx phy: 0x01 - LE 1M, 0x03 - LE 1M + LE 2M, 0x05 - LE 1M + LE CODED, 0x07 -  LE 1M + LE 2M +  LE CODED
+  cmd.writeUInt8(0x05, 6); // rx phy: 0x01 - LE 1M, 0x03 - LE 1M + LE 2M, 0x05 - LE 1M + LE CODED, 0x07 -  LE 1M + LE 2M +  LE CODED
+
+  debug(`set all phys supporting - writing: ${cmd.toString('hex')}`);
+  this._socket.write(cmd);
+};
+
+Hci.prototype.setRandomMAC = function () {
+  const cmd = Buffer.alloc(10);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(OCF_SET_RANDOM_MAC | (OGF_LE_CTL << 10), 1);
+
+  // length
+  cmd.writeUInt8(0x06, 3);
+
+  // data
+  cmd.writeUInt8(0x05, 4); // mac 6 byte
+  cmd.writeUInt8(0x04, 5); // mac 5 byte
+  cmd.writeUInt8(0x03, 6); // mac 4 byte
+  cmd.writeUInt8(0x02, 7); // mac 3 byte
+  cmd.writeUInt8(0x01, 8); // mac 2 byte
+  cmd.writeUInt8(0x00, 9); // mac 1 byte
+
+  debug(`set random mac address - writing: ${cmd.toString('hex')}`);
+  this._socket.write(cmd);
+};
+
 Hci.prototype.setSocketFilter = function () {
   const filter = Buffer.alloc(14);
-  const typeMask = (1 << HCI_COMMAND_PKT) | (1 << HCI_EVENT_PKT) | (1 << HCI_ACLDATA_PKT);
-  const eventMask1 = (1 << EVT_DISCONN_COMPLETE) | (1 << EVT_ENCRYPT_CHANGE) | (1 << EVT_CMD_COMPLETE) | (1 << EVT_CMD_STATUS) | (1 << EVT_NUMBER_OF_COMPLETED_PACKETS);
-  const eventMask2 = (1 << (EVT_LE_META_EVENT - 32));
+  const typeMask =
+    (1 << HCI_COMMAND_PKT) | (1 << HCI_EVENT_PKT) | (1 << HCI_ACLDATA_PKT);
+  const eventMask1 =
+    (1 << EVT_DISCONN_COMPLETE) |
+    (1 << EVT_ENCRYPT_CHANGE) |
+    (1 << EVT_CMD_COMPLETE) |
+    (1 << EVT_CMD_STATUS) |
+    (1 << EVT_NUMBER_OF_COMPLETED_PACKETS);
+  const eventMask2 = 1 << (EVT_LE_META_EVENT - 32);
   const opcode = 0;
 
   filter.writeUInt32LE(typeMask, 0);
@@ -200,6 +273,20 @@ Hci.prototype.reset = function () {
   cmd.writeUInt8(0x00, 3);
 
   debug(`reset - writing: ${cmd.toString('hex')}`);
+  this._socket.write(cmd);
+};
+
+Hci.prototype.readSupportedCommands = function () {
+  const cmd = Buffer.alloc(4);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(READ_SUPPORTED_COMMANDS_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x0, 3);
+
+  debug(`read supported commands - writing: ${cmd.toString('hex')}`);
   this._socket.write(cmd);
 };
 
@@ -247,7 +334,9 @@ Hci.prototype.readBdAddr = function () {
 
 Hci.prototype.setLeEventMask = function () {
   const cmd = Buffer.alloc(12);
-  const leEventMask = Buffer.from('1f00000000000000', 'hex');
+  const leEventMask = this._isExtended
+    ? Buffer.from('1fff000000000000', 'hex')
+    : Buffer.from('1f00000000000000', 'hex');
 
   // header
   cmd.writeUInt8(HCI_COMMAND_PKT, 0);
@@ -308,79 +397,167 @@ Hci.prototype.writeLeHostSupported = function () {
   this._socket.write(cmd);
 };
 
-Hci.prototype.setScanParameters = function (interval = 0x0010, window = 0x0010) {
-  const cmd = Buffer.alloc(11);
+Hci.prototype.setScanParameters = function (
+  interval = 0x0012,
+  window = 0x0012
+) {
+  const cmd = Buffer.alloc(this._isExtended ? 17 : 11);
 
   // header
   cmd.writeUInt8(HCI_COMMAND_PKT, 0);
-  cmd.writeUInt16LE(LE_SET_SCAN_PARAMETERS_CMD, 1);
+  cmd.writeUInt16LE(
+    this._isExtended
+      ? LE_SET_EXTENDED_SCAN_PARAMETERS_CMD
+      : LE_SET_SCAN_PARAMETERS_CMD,
+    1
+  );
 
-  // length
-  cmd.writeUInt8(0x07, 3);
+  if (this._isExtended) {
+    // length
+    cmd.writeUInt8(0x0d, 3);
 
-  // data
-  cmd.writeUInt8(0x01, 4); // type: 0 -> passive, 1 -> active
-  cmd.writeUInt16LE(interval, 5); // interval, ms * 1.6
-  cmd.writeUInt16LE(window, 7); // window, ms * 1.6
-  cmd.writeUInt8(0x00, 9); // own address type: 0 -> public, 1 -> random
-  cmd.writeUInt8(0x00, 10); // filter: 0 -> all event types
+    // data
+    cmd.writeUInt8(0x00, 4); // own address type: 0 -> public, 1 -> random
+    cmd.writeUInt8(0x00, 5); // filter: 0 -> all event types
+    cmd.writeUInt8(0x05, 6); // phy: LE 1M + LE CODED
+    // phy 1M
+    cmd.writeUInt8(0x01, 7); // type: 0 -> passive, 1 -> active
+    cmd.writeUInt16LE(interval, 8); // interval, ms * 1.6
+    cmd.writeUInt16LE(window, 10); // window, ms * 1.6
+    // phy coded
+    cmd.writeUInt8(0x01, 12); // type: 0 -> passive, 1 -> active
+    cmd.writeUInt16LE(interval, 13); // interval, ms * 1.6
+    cmd.writeUInt16LE(window, 15); // window, ms * 1.6
+  } else {
+    // length
+    cmd.writeUInt8(0x07, 3);
+
+    // data
+    cmd.writeUInt8(0x01, 4); // type: 0 -> passive, 1 -> active
+    cmd.writeUInt16LE(interval, 5); // interval, ms * 1.6
+    cmd.writeUInt16LE(window, 7); // window, ms * 1.6
+    cmd.writeUInt8(0x00, 9); // own address type: 0 -> public, 1 -> random
+    cmd.writeUInt8(0x00, 10); // filter: 0 -> all event types
+  }
 
   debug(`set scan parameters - writing: ${cmd.toString('hex')}`);
   this._socket.write(cmd);
 };
 
 Hci.prototype.setScanEnabled = function (enabled, filterDuplicates) {
-  const cmd = Buffer.alloc(6);
+  const cmd = Buffer.alloc(this._isExtended ? 10 : 6);
 
   // header
   cmd.writeUInt8(HCI_COMMAND_PKT, 0);
-  cmd.writeUInt16LE(LE_SET_SCAN_ENABLE_CMD, 1);
+  cmd.writeUInt16LE(
+    this._isExtended ? LE_SET_EXTENDED_SCAN_ENABLE_CMD : LE_SET_SCAN_ENABLE_CMD,
+    1
+  );
 
-  // length
-  cmd.writeUInt8(0x02, 3);
+  if (this._isExtended) {
+    // length
+    cmd.writeUInt8(0x06, 3);
 
-  // data
-  cmd.writeUInt8(enabled ? 0x01 : 0x00, 4); // enable: 0 -> disabled, 1 -> enabled
-  cmd.writeUInt8(filterDuplicates ? 0x01 : 0x00, 5); // duplicates: 0 -> duplicates, 0 -> duplicates
+    // data
+    cmd.writeUInt8(enabled ? 0x01 : 0x00, 4); // enable: 0 -> disabled, 1 -> enabled
+    cmd.writeUInt8(filterDuplicates ? 0x01 : 0x00, 5); // duplicates: 0 -> duplicates, 1 -> all
+    cmd.writeUInt16LE(0x0000, 6); // duration
+    cmd.writeUInt16LE(0x0000, 8); // period
+  } else {
+    // length
+    cmd.writeUInt8(0x02, 3);
+
+    // data
+    cmd.writeUInt8(enabled ? 0x01 : 0x00, 4); // enable: 0 -> disabled, 1 -> enabled
+    cmd.writeUInt8(filterDuplicates ? 0x01 : 0x00, 5); // duplicates: 0 -> duplicates, 0 -> duplicates
+  }
 
   debug(`set scan enabled - writing: ${cmd.toString('hex')}`);
   this._socket.write(cmd);
 };
 
 Hci.prototype.createLeConn = function (address, addressType, parameters = {}) {
-  const { minInterval = 0x0006, maxInterval = 0x000c, latency = 0x0000, timeout = 0x00c8 } = parameters;
+  const {
+    minInterval = 0x0006,
+    maxInterval = 0x0012,
+    latency = 0x0000,
+    timeout = 0x002a
+  } = parameters;
 
-  const cmd = Buffer.alloc(29);
+  const cmd = Buffer.alloc(this._isExtended ? 46 : 29);
 
   // header
   cmd.writeUInt8(HCI_COMMAND_PKT, 0);
-  cmd.writeUInt16LE(LE_CREATE_CONN_CMD, 1);
+  cmd.writeUInt16LE(
+    this._isExtended
+      ? LE_CREATE_EXTENDED_CONN_CMD
+      : LE_CREATE_CONN_CMD,
+    1
+  );
 
-  // length
-  cmd.writeUInt8(0x19, 3);
+  if (this._isExtended) {
+    // length
+    cmd.writeUInt8(0x2a, 3);
 
-  // data
-  cmd.writeUInt16LE(0x0060, 4); // interval
-  cmd.writeUInt16LE(0x0030, 6); // window
-  cmd.writeUInt8(0x00, 8); // initiator filter
+    // data
+    cmd.writeUInt8(0x00, 4); // filter policy: white list is not used
+    cmd.writeUInt8(0x00, 5); // own address type
+    cmd.writeUInt8(addressType === 'random' ? 0x01 : 0x00, 6); // peer address type
+    Buffer.from(address.split(':').reverse().join(''), 'hex').copy(cmd, 7); // peer address
+    cmd.writeUInt8(0x05, 13); // initiating PHYs: LE 1M + LE Coded
 
-  cmd.writeUInt8(addressType === 'random' ? 0x01 : 0x00, 9); // peer address type
-  (Buffer.from(address.split(':').reverse().join(''), 'hex')).copy(cmd, 10); // peer address
+    // LE 1M PHY
+    cmd.writeUInt16LE(0x0060, 14); // scan interval 60 msec
+    cmd.writeUInt16LE(0x0060, 16); // scan window 60 msec
+    cmd.writeUInt16LE(minInterval, 18); // min interval
+    cmd.writeUInt16LE(maxInterval, 20); // max interval
+    cmd.writeUInt16LE(latency, 22); // latency
+    cmd.writeUInt16LE(timeout, 24); // supervision timeout
+    cmd.writeUInt16LE(0x0000, 26); // min ce length
+    cmd.writeUInt16LE(0x0000, 28); // max ce length
 
-  cmd.writeUInt8(0x00, 16); // own address type
+    // LE Coded PHY
+    cmd.writeUInt16LE(0x0060, 30); // scan interval 60 msec
+    cmd.writeUInt16LE(0x0060, 32); // scan window 60 msec
+    cmd.writeUInt16LE(minInterval, 34); // min interval
+    cmd.writeUInt16LE(maxInterval, 36); // max interval
+    cmd.writeUInt16LE(latency, 38); // latency
+    cmd.writeUInt16LE(timeout, 40); // supervision timeout
+    cmd.writeUInt16LE(0x0000, 42); // min ce length
+    cmd.writeUInt16LE(0x0000, 44); // max ce length
+  } else {
+    // length
+    cmd.writeUInt8(0x19, 3);
 
-  cmd.writeUInt16LE(minInterval, 17); // min interval
-  cmd.writeUInt16LE(maxInterval, 19); // max interval
-  cmd.writeUInt16LE(latency, 21); // latency
-  cmd.writeUInt16LE(timeout, 23); // supervision timeout
-  cmd.writeUInt16LE(0x0004, 25); // min ce length
-  cmd.writeUInt16LE(0x0006, 27); // max ce length
+    // data
+    cmd.writeUInt16LE(0x0060, 4); // interval
+    cmd.writeUInt16LE(0x0030, 6); // window
+    cmd.writeUInt8(0x00, 8); // initiator filter
+
+    cmd.writeUInt8(addressType === 'random' ? 0x01 : 0x00, 9); // peer address type
+    Buffer.from(address.split(':').reverse().join(''), 'hex').copy(cmd, 10); // peer address
+
+    cmd.writeUInt8(0x00, 16); // own address type
+
+    cmd.writeUInt16LE(minInterval, 17); // min interval
+    cmd.writeUInt16LE(maxInterval, 19); // max interval
+    cmd.writeUInt16LE(latency, 21); // latency
+    cmd.writeUInt16LE(timeout, 23); // supervision timeout
+    cmd.writeUInt16LE(0x0004, 25); // min ce length
+    cmd.writeUInt16LE(0x0006, 27); // max ce length
+  }
 
   debug(`create le conn - writing: ${cmd.toString('hex')}`);
   this._socket.write(cmd);
 };
 
-Hci.prototype.connUpdateLe = function (handle, minInterval, maxInterval, latency, supervisionTimeout) {
+Hci.prototype.connUpdateLe = function (
+  handle,
+  minInterval,
+  maxInterval,
+  latency,
+  supervisionTimeout
+) {
   const cmd = Buffer.alloc(18);
 
   // header
@@ -483,7 +660,7 @@ Hci.prototype.writeAclDataPkt = function (handle, cid, data) {
 
   // acl header
   first.writeUInt8(HCI_ACLDATA_PKT, 0);
-  first.writeUInt16LE(handle | ACL_START_NO_FLUSH << 12, 1);
+  first.writeUInt16LE(handle | (ACL_START_NO_FLUSH << 12), 1);
   first.writeUInt16LE(aclLength, 3);
 
   // l2cap header
@@ -501,7 +678,7 @@ Hci.prototype.writeAclDataPkt = function (handle, cid, data) {
     const frag = Buffer.alloc(fragAclLength + 5 /* acl header */);
     // acl header
     frag.writeUInt8(HCI_ACLDATA_PKT, 0);
-    frag.writeUInt16LE(handle | ACL_CONT << 12, 1);
+    frag.writeUInt16LE(handle | (ACL_CONT << 12), 1);
     frag.writeUInt16LE(fragAclLength, 3);
 
     data.copy(frag, 5);
@@ -517,11 +694,17 @@ Hci.prototype.writeAclDataPkt = function (handle, cid, data) {
 Hci.prototype.flushAcl = function () {
   const pendingPackets = () => {
     let totalPending = 0;
-    for (const { pending } of this._aclConnections.values()) { totalPending += pending; }
+    for (const { pending } of this._aclConnections.values()) {
+      totalPending += pending;
+    }
     return totalPending;
   };
 
-  debug(`flush - pending: ${pendingPackets()} queue length: ${this._aclQueue.length}`);
+  debug(
+    `flush - pending: ${pendingPackets()} queue length: ${
+      this._aclQueue.length
+    }`
+  );
 
   while (this._aclQueue.length > 0 && pendingPackets() < this._aclBuffers.num) {
     const { handle, packet } = this._aclQueue.shift();
@@ -553,7 +736,7 @@ Hci.prototype.onSocketData = function (data) {
       debug(`\t\thandle = ${handle}`);
       debug(`\t\treason = ${reason}`);
 
-      this._aclQueue = this._aclQueue.filter(acl => acl.handle !== handle);
+      this._aclQueue = this._aclQueue.filter((acl) => acl.handle !== handle);
       this._aclConnections.delete(handle);
       this.flushAcl();
 
@@ -585,15 +768,21 @@ Hci.prototype.onSocketData = function (data) {
 
       this.processCmdStatusEvent(cmd, status);
     } else if (subEventType === EVT_LE_META_EVENT) {
+      const leMetaEventLength = data.readUInt8(2);
       const leMetaEventType = data.readUInt8(3);
-      const leMetaEventStatus = data.readUInt8(4);
+      const leMetaEventNumReports = data.readUInt8(4);
       const leMetaEventData = data.slice(5);
 
       debug(`\t\tLE meta event type = ${leMetaEventType}`);
-      debug(`\t\tLE meta event status = ${leMetaEventStatus}`);
+      debug(`\t\tLE meta event data length = ${leMetaEventLength}`);
+      debug(`\t\tLE meta event num reports = ${leMetaEventNumReports}`);
       debug(`\t\tLE meta event data = ${leMetaEventData.toString('hex')}`);
 
-      this.processLeMetaEvent(leMetaEventType, leMetaEventStatus, leMetaEventData);
+      this.processLeMetaEvent(
+        leMetaEventType,
+        leMetaEventNumReports,
+        leMetaEventData
+      );
     } else if (subEventType === EVT_NUMBER_OF_COMPLETED_PACKETS) {
       const handles = data.readUInt8(3);
       for (let h = 0; h < handles; h++) {
@@ -611,7 +800,9 @@ Hci.prototype.onSocketData = function (data) {
 
         connection.pending -= pkts;
 
-        if (connection.pending < 0) { connection.pending = 0; }
+        if (connection.pending < 0) {
+          connection.pending = 0;
+        }
       }
       this.flushAcl();
     }
@@ -649,8 +840,16 @@ Hci.prototype.onSocketData = function (data) {
         data.slice(5)
       ]);
 
-      if (this._handleBuffers[handle].data.length === this._handleBuffers[handle].length) {
-        this.emit('aclDataPkt', handle, this._handleBuffers[handle].cid, this._handleBuffers[handle].data);
+      if (
+        this._handleBuffers[handle].data.length ===
+        this._handleBuffers[handle].length
+      ) {
+        this.emit(
+          'aclDataPkt',
+          handle,
+          this._handleBuffers[handle].cid,
+          this._handleBuffers[handle].data
+        );
 
         delete this._handleBuffers[handle];
       }
@@ -662,9 +861,12 @@ Hci.prototype.onSocketData = function (data) {
     debug(`\t\tcmd = ${cmd}`);
     debug(`\t\tdata len = ${len}`);
 
-    if (cmd === LE_SET_SCAN_ENABLE_CMD) {
-      const enable = (data.readUInt8(4) === 0x1);
-      const filterDuplicates = (data.readUInt8(5) === 0x1);
+    if (
+      cmd === LE_SET_SCAN_ENABLE_CMD ||
+      cmd === LE_SET_EXTENDED_SCAN_ENABLE_CMD
+    ) {
+      const enable = data.readUInt8(4) === 0x1;
+      const filterDuplicates = data.readUInt8(5) === 0x1;
 
       debug('\t\t\tLE enable scan command');
       debug(`\t\t\tenable scanning = ${enable}`);
@@ -687,6 +889,9 @@ Hci.prototype.onSocketError = function (error) {
 
 Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
   if (cmd === RESET_CMD) {
+    if (this._isExtended) {
+      this.setCodedPhySupport();
+    }
     this.setEventMask();
     this.setLeEventMask();
     this.readLocalVersion();
@@ -713,19 +918,47 @@ Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
       this.setScanParameters();
     }
 
-    this.emit('readLocalVersion', hciVer, hciRev, lmpVer, manufacturer, lmpSubVer);
+    this.emit(
+      'readLocalVersion',
+      hciVer,
+      hciRev,
+      lmpVer,
+      manufacturer,
+      lmpSubVer
+    );
+  } else if (cmd === READ_SUPPORTED_COMMANDS_CMD) {
+    const extendedScanParameters = result.readUInt8(37) & 0x10; // LE Set Extended Scan Parameters (Octet 37 - Bit 5)
+    const extendedScan = result.readUInt8(37) & 0x20; // LE Set Extended Scan Enable (Octet 37 - Bit 6)
+
+    debug(
+      `Extended advertising features: parameters = ${
+        extendedScanParameters ? 'true' : 'false'
+      }, num = ${extendedScan ? 'true' : 'false'}`
+    );
+
+    this._isExtended = extendedScanParameters && extendedScan;
   } else if (cmd === READ_BD_ADDR_CMD) {
     this.addressType = 'public';
-    this.address = result.toString('hex').match(/.{1,2}/g).reverse().join(':');
+    this.address = result
+      .toString('hex')
+      .match(/.{1,2}/g)
+      .reverse()
+      .join(':');
 
     debug(`address = ${this.address}`);
 
     this.emit('addressChange', this.address);
-  } else if (cmd === LE_SET_SCAN_PARAMETERS_CMD) {
+  } else if (
+    cmd === LE_SET_SCAN_PARAMETERS_CMD ||
+    cmd === LE_SET_EXTENDED_SCAN_PARAMETERS_CMD
+  ) {
     this.emit('stateChange', 'poweredOn');
 
     this.emit('leScanParametersSet');
-  } else if (cmd === LE_SET_SCAN_ENABLE_CMD) {
+  } else if (
+    cmd === LE_SET_SCAN_ENABLE_CMD ||
+    cmd === LE_SET_EXTENDED_SCAN_ENABLE_CMD
+  ) {
     this.emit('leScanEnableSet', status);
   } else if (cmd === READ_RSSI_CMD) {
     const handle = result.readUInt16LE(0);
@@ -761,13 +994,17 @@ Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
   }
 };
 
-Hci.prototype.processLeMetaEvent = function (eventType, status, data) {
+Hci.prototype.processLeMetaEvent = function (eventType, numReports, data) {
   if (eventType === EVT_LE_CONN_COMPLETE) {
-    this.processLeConnComplete(status, data);
+    this.processLeConnComplete(numReports, data);
+  } else if (eventType === EVT_LE_ENHANCED_CONN_COMPLETE) {
+    this.processLeEnhancedConnComplete(numReports, data);
   } else if (eventType === EVT_LE_ADVERTISING_REPORT) {
-    this.processLeAdvertisingReport(status, data);
+    this.processLeAdvertisingReport(numReports, data);
+  } else if (eventType === EVT_LE_EXTENDED_ADVERTISING_REPORT) {
+    this.processLeExtendedAdvertisingReport(numReports, data);
   } else if (eventType === EVT_LE_CONN_UPDATE_COMPLETE) {
-    this.processLeConnUpdateComplete(status, data);
+    this.processLeConnUpdateComplete(numReports, data);
   }
 };
 
@@ -775,7 +1012,12 @@ Hci.prototype.processLeConnComplete = function (status, data) {
   const handle = data.readUInt16LE(0);
   const role = data.readUInt8(2);
   const addressType = data.readUInt8(3) === 0x01 ? 'random' : 'public';
-  const address = data.slice(4, 10).toString('hex').match(/.{1,2}/g).reverse().join(':');
+  const address = data
+    .slice(4, 10)
+    .toString('hex')
+    .match(/.{1,2}/g)
+    .reverse()
+    .join(':');
   const interval = data.readUInt16LE(10) * 1.25;
   const latency = data.readUInt16LE(12); // TODO: multiplier?
   const supervisionTimeout = data.readUInt16LE(14) * 10;
@@ -792,15 +1034,89 @@ Hci.prototype.processLeConnComplete = function (status, data) {
 
   this._aclConnections.set(handle, { pending: 0 });
 
-  this.emit('leConnComplete', status, handle, role, addressType, address, interval, latency, supervisionTimeout, masterClockAccuracy);
+  this.emit(
+    'leConnComplete',
+    status,
+    handle,
+    role,
+    addressType,
+    address,
+    interval,
+    latency,
+    supervisionTimeout,
+    masterClockAccuracy
+  );
 };
 
-Hci.prototype.processLeAdvertisingReport = function (count, data) {
+Hci.prototype.processLeEnhancedConnComplete = function (status, data) {
+  const handle = data.readUInt16LE(0);
+  const role = data.readUInt8(2);
+  const addressType = data.readUInt8(3) === 0x01 ? 'random' : 'public';
+  const address = data
+    .slice(4, 10)
+    .toString('hex')
+    .match(/.{1,2}/g)
+    .reverse()
+    .join(':');
+  const localResolvablePrivateAddress = data
+    .slice(10, 16)
+    .toString('hex')
+    .match(/.{1,2}/g)
+    .reverse()
+    .join(':');
+  const peerResolvablePrivateAddress = data
+    .slice(16, 22)
+    .toString('hex')
+    .match(/.{1,2}/g)
+    .reverse()
+    .join(':');
+  const interval = data.readUInt16LE(22) * 1.25;
+  const latency = data.readUInt16LE(24); // TODO: multiplier?
+  const supervisionTimeout = data.readUInt16LE(26) * 10;
+  const masterClockAccuracy = data.readUInt8(28); // TODO: multiplier?
+
+  debug(`\t\t\thandle = ${handle}`);
+  debug(`\t\t\trole = ${role}`);
+  debug(`\t\t\taddress type = ${addressType}`);
+  debug(`\t\t\taddress = ${address}`);
+  debug(
+    `\t\t\tLocal resolvable private address = ${localResolvablePrivateAddress}`
+  );
+  debug(
+    `\t\t\tPeer resolvable private address = ${peerResolvablePrivateAddress}`
+  );
+  debug(`\t\t\tinterval = ${interval}`);
+  debug(`\t\t\tlatency = ${latency}`);
+  debug(`\t\t\tsupervision timeout = ${supervisionTimeout}`);
+  debug(`\t\t\tmaster clock accuracy = ${masterClockAccuracy}`);
+
+  this._aclConnections.set(handle, { pending: 0 });
+
+  this.emit(
+    'leConnComplete',
+    status,
+    handle,
+    role,
+    addressType,
+    address,
+    interval,
+    latency,
+    supervisionTimeout,
+    masterClockAccuracy
+  );
+};
+
+Hci.prototype.processLeAdvertisingReport = function (numReports, data) {
   try {
-    for (let i = 0; i < count; i++) {
+    for (let i = 0; i < numReports; i++) {
       const type = data.readUInt8(0);
       const addressType = data.readUInt8(1) === 0x01 ? 'random' : 'public';
-      const address = data.slice(2, 8).toString('hex').match(/.{1,2}/g).reverse().join(':');
+      const address = data
+        .slice(2, 8)
+        .toString('hex')
+        .match(/.{1,2}/g)
+        .reverse()
+        .join(':');
       const eirLength = data.readUInt8(8);
       const eir = data.slice(9, eirLength + 9);
       const rssi = data.readInt8(eirLength + 9);
@@ -811,12 +1127,86 @@ Hci.prototype.processLeAdvertisingReport = function (count, data) {
       debug(`\t\t\teir = ${eir.toString('hex')}`);
       debug(`\t\t\trssi = ${rssi}`);
 
-      this.emit('leAdvertisingReport', 0, type, address, addressType, eir, rssi);
+      this.emit(
+        'leAdvertisingReport',
+        0,
+        type,
+        address,
+        addressType,
+        eir,
+        rssi
+      );
 
       data = data.slice(eirLength + 10);
     }
   } catch (e) {
-    console.warn(`processLeAdvertisingReport: Caught illegal packet (buffer overflow): ${e}`);
+    console.warn(
+      `processLeAdvertisingReport: Caught illegal packet (buffer overflow): ${e}`
+    );
+  }
+};
+
+Hci.prototype.processLeExtendedAdvertisingReport = function (numReports, data) {
+  try {
+    for (let i = 0; i < numReports; i++) {
+      const type = data.readUInt16LE(0);
+      const addressType = data.readUInt8(2) === 0x01 ? 'random' : 'public';
+      const address = data
+        .slice(3, 9)
+        .toString('hex')
+        .match(/.{1,2}/g)
+        .reverse()
+        .join(':');
+      const primaryPHY = data.readUInt8(9);
+      const secondaryPHY = data.readUInt8(10);
+      const sid = data.readUInt8(11);
+      const txpower = data.readUInt8(12);
+      const rssi = data.readInt8(13);
+      const periodicAdvInterval = data.readUInt16LE(14);
+      const directAddressType =
+        data.readUInt8(16) === 0x01 ? 'random' : 'public';
+      const directAddress = data
+        .slice(17, 23)
+        .toString('hex')
+        .match(/.{1,2}/g)
+        .reverse()
+        .join(':');
+      const eirLength = data.readUInt8(23);
+      const eir = data.slice(24);
+
+      debug(`\t\t\ttype = ${type}`);
+      debug(`\t\t\taddress = ${address}`);
+      debug(`\t\t\taddress type = ${addressType}`);
+      debug(`\t\t\tprimary phy = ${primaryPHY.toString(16)}`);
+      debug(`\t\t\tsecondary phy = ${secondaryPHY.toString(16)}`);
+      debug(`\t\t\tSID = ${sid.toString(16)}`);
+      debug(`\t\t\tTX power = ${txpower}`);
+      debug(`\t\t\tRSSI = ${rssi}`);
+      debug(
+        `\t\t\tperiodic advertising interval = ${periodicAdvInterval} msec`
+      );
+      debug(`\t\t\tdirect address type = ${directAddressType}`);
+      debug(`\t\t\tdirect address = ${directAddress}`);
+      debug(`\t\t\teir length = ${eirLength}`);
+      debug(`\t\t\teir = ${eir.toString('hex')}`);
+
+      this.emit(
+        'leExtendedAdvertisingReport',
+        0,
+        type,
+        address,
+        addressType,
+        txpower,
+        rssi,
+        eir
+      );
+
+      data = data.slice(eirLength + 24);
+    }
+  } catch (e) {
+    console.warn(
+      `processLeExtendedAdvertisingReport: Caught illegal packet (buffer overflow): ${e}`
+    );
   }
 };
 
@@ -831,11 +1221,18 @@ Hci.prototype.processLeConnUpdateComplete = function (status, data) {
   debug(`\t\t\tlatency = ${latency}`);
   debug(`\t\t\tsupervision timeout = ${supervisionTimeout}`);
 
-  this.emit('leConnUpdateComplete', status, handle, interval, latency, supervisionTimeout);
+  this.emit(
+    'leConnUpdateComplete',
+    status,
+    handle,
+    interval,
+    latency,
+    supervisionTimeout
+  );
 };
 
 Hci.prototype.processCmdStatusEvent = function (cmd, status) {
-  if (cmd === LE_CREATE_CONN_CMD) {
+  if (cmd === LE_CREATE_CONN_CMD || cmd === LE_CREATE_EXTENDED_CONN_CMD) {
     if (status !== 0) {
       this.emit('leConnComplete', status);
     }

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -181,11 +181,11 @@ Noble.prototype.reset = function () {
   this._bindings.reset();
 };
 
-Noble.prototype.onDiscover = function (uuid, address, addressType, connectable, advertisement, rssi) {
+Noble.prototype.onDiscover = function (uuid, address, addressType, connectable, advertisement, rssi, scannable) {
   let peripheral = this._peripherals[uuid];
 
   if (!peripheral) {
-    peripheral = new Peripheral(this, uuid, address, addressType, connectable, advertisement, rssi);
+    peripheral = new Peripheral(this, uuid, address, addressType, connectable, advertisement, rssi, scannable);
 
     this._peripherals[uuid] = peripheral;
     this._services[uuid] = {};
@@ -200,6 +200,7 @@ Noble.prototype.onDiscover = function (uuid, address, addressType, connectable, 
     }
 
     peripheral.connectable = connectable;
+    peripheral.scannable = scannable;
     peripheral.rssi = rssi;
   }
 
@@ -209,7 +210,7 @@ Noble.prototype.onDiscover = function (uuid, address, addressType, connectable, 
     this._discoveredPeripheralUUids.push(uuid);
   }
 
-  if (this._allowDuplicates || !previouslyDiscoverd) {
+  if (this._allowDuplicates || !previouslyDiscoverd || (!scannable && !connectable)) {
     this.emit('discover', peripheral);
   }
 };

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -3,7 +3,7 @@ const util = require('util');
 
 const Manufacturer = require('./manufacture');
 
-function Peripheral (noble, id, address, addressType, connectable, advertisement, rssi) {
+function Peripheral (noble, id, address, addressType, connectable, advertisement, rssi, scannable) {
   this._noble = noble;
 
   this.id = id;
@@ -11,6 +11,7 @@ function Peripheral (noble, id, address, addressType, connectable, advertisement
   this.address = address;
   this.addressType = addressType;
   this.connectable = connectable;
+  this.scannable = scannable;
   this.advertisement = advertisement;
   this.rssi = rssi;
   this.services = null;

--- a/lib/resolve-bindings.js
+++ b/lib/resolve-bindings.js
@@ -1,10 +1,17 @@
 const os = require('os');
 
 function getWindowsBindings () {
-  const ver = os.release().split('.').map(str => parseInt(str, 10));
-  if (!(ver[0] > 10 ||
-    (ver[0] === 10 && ver[1] > 0) ||
-    (ver[0] === 10 && ver[1] === 0 && ver[2] >= 15063))) {
+  const ver = os
+    .release()
+    .split('.')
+    .map((str) => parseInt(str, 10));
+  if (
+    !(
+      ver[0] > 10 ||
+      (ver[0] === 10 && ver[1] > 0) ||
+      (ver[0] === 10 && ver[1] === 0 && ver[2] >= 15063)
+    )
+  ) {
     return require('./hci-socket/bindings');
   } else {
     return require('./win/bindings');
@@ -18,12 +25,17 @@ module.exports = function (options) {
     return new (require('./websocket/bindings'))(options);
   } else if (process.env.NOBLE_DISTRIBUTED) {
     return new (require('./distributed/bindings'))(options);
+  } else if (
+    platform === 'linux' ||
+    platform === 'freebsd' ||
+    (process.env.BLUETOOTH_HCI_SOCKET_USB_VID &&
+      process.env.BLUETOOTH_HCI_SOCKET_USB_PID)
+  ) {
+    return new (require('./hci-socket/bindings'))(options);
   } else if (platform === 'darwin') {
     return new (require('./mac/bindings'))(options);
   } else if (platform === 'win32') {
     return new (getWindowsBindings())(options);
-  } else if (platform === 'linux' || platform === 'freebsd') {
-    return new (require('./hci-socket/bindings'))(options);
   } else {
     throw new Error('Unsupported platform');
   }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-const noble = require('./index');
+const noble = require('./index')({ extended: false });
 
 console.log('noble');
 
@@ -6,7 +6,7 @@ noble.on('stateChange', function (state) {
   console.log('on -> stateChange: ' + state);
 
   if (state === 'poweredOn') {
-    noble.startScanning();
+    noble.startScanning([], true);
   } else {
     noble.stopScanning();
   }
@@ -44,67 +44,85 @@ noble.on('discover', function (peripheral) {
 
     const serviceIndex = 0;
 
-    services[serviceIndex].on('includedServicesDiscover', function (includedServiceUuids) {
-      console.log('on -> service included services discovered ' + includedServiceUuids);
-      this.discoverCharacteristics();
-    });
+    services[serviceIndex].on(
+      'includedServicesDiscover',
+      function (includedServiceUuids) {
+        console.log(
+          'on -> service included services discovered ' + includedServiceUuids
+        );
+        this.discoverCharacteristics();
+      }
+    );
 
-    services[serviceIndex].on('characteristicsDiscover', function (characteristics) {
-      console.log('on -> service characteristics discovered ' + characteristics);
+    services[serviceIndex].on(
+      'characteristicsDiscover',
+      function (characteristics) {
+        console.log(
+          'on -> service characteristics discovered ' + characteristics
+        );
 
-      const characteristicIndex = 0;
+        const characteristicIndex = 0;
 
-      characteristics[characteristicIndex].on('read', function (data, isNotification) {
-        console.log('on -> characteristic read ' + data + ' ' + isNotification);
-        console.log(data);
+        characteristics[characteristicIndex].on(
+          'read',
+          function (data, isNotification) {
+            console.log(
+              'on -> characteristic read ' + data + ' ' + isNotification
+            );
+            console.log(data);
 
-        peripheral.disconnect();
-      });
+            peripheral.disconnect();
+          }
+        );
 
-      characteristics[characteristicIndex].on('write', function () {
-        console.log('on -> characteristic write ');
+        characteristics[characteristicIndex].on('write', function () {
+          console.log('on -> characteristic write ');
 
-        peripheral.disconnect();
-      });
-
-      characteristics[characteristicIndex].on('broadcast', function (state) {
-        console.log('on -> characteristic broadcast ' + state);
-
-        peripheral.disconnect();
-      });
-
-      characteristics[characteristicIndex].on('notify', function (state) {
-        console.log('on -> characteristic notify ' + state);
-
-        peripheral.disconnect();
-      });
-
-      characteristics[characteristicIndex].on('descriptorsDiscover', function (descriptors) {
-        console.log('on -> descriptors discover ' + descriptors);
-
-        const descriptorIndex = 0;
-
-        descriptors[descriptorIndex].on('valueRead', function (data) {
-          console.log('on -> descriptor value read ' + data);
-          console.log(data);
           peripheral.disconnect();
         });
 
-        descriptors[descriptorIndex].on('valueWrite', function () {
-          console.log('on -> descriptor value write ');
+        characteristics[characteristicIndex].on('broadcast', function (state) {
+          console.log('on -> characteristic broadcast ' + state);
+
           peripheral.disconnect();
         });
 
-        descriptors[descriptorIndex].readValue();
-        // descriptors[descriptorIndex].writeValue(new Buffer([0]));
-      });
+        characteristics[characteristicIndex].on('notify', function (state) {
+          console.log('on -> characteristic notify ' + state);
 
-      characteristics[characteristicIndex].read();
-      // characteristics[characteristicIndex].write(new Buffer('hello'));
-      // characteristics[characteristicIndex].broadcast(true);
-      // characteristics[characteristicIndex].notify(true);
-      // characteristics[characteristicIndex].discoverDescriptors();
-    });
+          peripheral.disconnect();
+        });
+
+        characteristics[characteristicIndex].on(
+          'descriptorsDiscover',
+          function (descriptors) {
+            console.log('on -> descriptors discover ' + descriptors);
+
+            const descriptorIndex = 0;
+
+            descriptors[descriptorIndex].on('valueRead', function (data) {
+              console.log('on -> descriptor value read ' + data);
+              console.log(data);
+              peripheral.disconnect();
+            });
+
+            descriptors[descriptorIndex].on('valueWrite', function () {
+              console.log('on -> descriptor value write ');
+              peripheral.disconnect();
+            });
+
+            descriptors[descriptorIndex].readValue();
+            // descriptors[descriptorIndex].writeValue(new Buffer([0]));
+          }
+        );
+
+        characteristics[characteristicIndex].read();
+        // characteristics[characteristicIndex].write(new Buffer('hello'));
+        // characteristics[characteristicIndex].broadcast(true);
+        // characteristics[characteristicIndex].notify(true);
+        // characteristics[characteristicIndex].discoverDescriptors();
+      }
+    );
 
     services[serviceIndex].discoverIncludedServices();
   });


### PR DESCRIPTION
add ble5 extended advertising scan and view with data length more then 31 byte
to scan with custom hci-usb ble5 dongle you need to add
BLUETOOTH_HCI_SOCKET_USB_VID=xxx
BLUETOOTH_HCI_SOCKET_USB_PID=xxx
parameters to your process env before scanning start
by default LE 1M and LE CODED are used

Possibly close https://github.com/abandonware/noble/issues/200