### PR TITLE
 Fix for Issue 246

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -656,7 +656,9 @@ Hci.prototype.writeAclDataPkt = function (handle, cid, data) {
 
   const aclLength = Math.min(l2capLength, this._aclBuffers.length);
 
-  const first = Buffer.alloc(aclLength + 5 /* acl header */);
+  // set minimum buffer size to be large enough to handle acl header
+  // and l2cap header (9)
+  const first = Buffer.alloc(Math.max(aclLength + 5 /* acl header */, 9));
 
   // acl header
   first.writeUInt8(HCI_ACLDATA_PKT, 0);


### PR DESCRIPTION
fix: allocate minimum space in the 'first' buffer to prevent writing out of bounds when aclLength is < 4

[Issue 246](https://github.com/abandonware/noble/issues/246)