### PR TITLE
fix: issue 246, caused by race condition where _aclBuffers is not set when writeAclDataPkt is called

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -103,10 +103,27 @@ const Hci = function (options) {
 
   this._handleBuffers = {};
 
-  this._aclBuffers = {
-    length: 0,
-    num: 0
-  };
+  this._aclBuffers = undefined;
+  this._resolveAclBuffers = undefined;
+  const aclBuffersPromise = new Promise((resolve) => {
+      this._resolveAclBuffers = resolve;
+  });
+  this.getAclBuffers = (async function() {
+      if(this._aclBuffers) return this._aclBuffers;
+      return await aclBuffersPromise;
+  }).bind(this);
+  this.setAclBuffers = (function (length, num) {
+      if(this._aclBuffers) {
+          this._aclBuffers.length = length;
+          this._aclBuffers.num = num;
+          return;
+      }
+      this._aclBuffers = {
+          length,
+          num
+      };
+      this._resolveAclBuffers(this._aclBuffers);
+  }).bind(this);
 
   this._aclConnections = new Map();
 
@@ -651,12 +668,14 @@ Hci.prototype.readRssi = function (handle) {
   this._socket.write(cmd);
 };
 
-Hci.prototype.writeAclDataPkt = function (handle, cid, data) {
+Hci.prototype.writeAclDataPkt = async function (handle, cid, data) {
   const l2capLength = 4 /* l2cap header */ + data.length;
 
-  const aclLength = Math.min(l2capLength, this._aclBuffers.length);
+  const aclBuffers = await this.getAclBuffers();
+  const aclLength = Math.min(l2capLength, aclBuffers.length);
 
-  const first = Buffer.alloc(aclLength + 5 /* acl header */);
+  const minFirstLength = Math.max(aclLength + 5 /* acl header */, 9 /* prevent buffer overflow */);
+  const first = Buffer.alloc(minFirstLength);
 
   // acl header
   first.writeUInt8(HCI_ACLDATA_PKT, 0);
@@ -674,7 +693,7 @@ Hci.prototype.writeAclDataPkt = function (handle, cid, data) {
   this._aclQueue.push({ handle, packet: first });
 
   while (data.length > 0) {
-    const fragAclLength = Math.min(data.length, this._aclBuffers.length);
+    const fragAclLength = Math.min(data.length, aclBuffers.length);
     const frag = Buffer.alloc(fragAclLength + 5 /* acl header */);
     // acl header
     frag.writeUInt8(HCI_ACLDATA_PKT, 0);
@@ -691,7 +710,7 @@ Hci.prototype.writeAclDataPkt = function (handle, cid, data) {
   this.flushAcl();
 };
 
-Hci.prototype.flushAcl = function () {
+Hci.prototype.flushAcl = async function () {
   const pendingPackets = () => {
     let totalPending = 0;
     for (const { pending } of this._aclConnections.values()) {
@@ -706,7 +725,8 @@ Hci.prototype.flushAcl = function () {
     }`
   );
 
-  while (this._aclQueue.length > 0 && pendingPackets() < this._aclBuffers.num) {
+  const aclBuffers = await this.getAclBuffers();
+  while (this._aclQueue.length > 0 && pendingPackets() < aclBuffers.num) {
     const { handle, packet } = this._aclQueue.shift();
     this._aclConnections.get(handle).pending++;
     debug(`write acl data packet - writing: ${packet.toString('hex')}`);
@@ -980,8 +1000,7 @@ Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
         this.readBufferSize();
       } else {
         debug(`le buffer size: length = ${aclLength}, num = ${aclNum}`);
-        this._aclBuffers.length = aclLength;
-        this._aclBuffers.num = aclNum;
+        this.setAclBuffers(aclLength, aclNum);
       }
     }
   } else if (cmd === READ_BUFFER_SIZE_CMD) {
@@ -989,8 +1008,7 @@ Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
     const aclNum = result.readUInt16LE(3);
 
     debug(`buffer size: length = ${aclLength}, num = ${aclNum}`);
-    this._aclBuffers.length = aclLength;
-    this._aclBuffers.num = aclNum;
+    this.setAclBuffers(aclLength, aclNum);
   }
 };
 

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -106,24 +106,24 @@ const Hci = function (options) {
   this._aclBuffers = undefined;
   this._resolveAclBuffers = undefined;
   const aclBuffersPromise = new Promise((resolve) => {
-      this._resolveAclBuffers = resolve;
+    this._resolveAclBuffers = resolve;
   });
-  this.getAclBuffers = (async function() {
-      if(this._aclBuffers) return this._aclBuffers;
-      return await aclBuffersPromise;
-  }).bind(this);
-  this.setAclBuffers = (function (length, num) {
-      if(this._aclBuffers) {
-          this._aclBuffers.length = length;
-          this._aclBuffers.num = num;
-          return;
-      }
-      this._aclBuffers = {
-          length,
-          num
-      };
-      this._resolveAclBuffers(this._aclBuffers);
-  }).bind(this);
+  this.getAclBuffers = async function () {
+    if (this._aclBuffers) return this._aclBuffers;
+    return await aclBuffersPromise;
+  }.bind(this);
+  this.setAclBuffers = function (length, num) {
+    if (this._aclBuffers) {
+      this._aclBuffers.length = length;
+      this._aclBuffers.num = num;
+      return;
+    }
+    this._aclBuffers = {
+      length,
+      num
+    };
+    this._resolveAclBuffers(this._aclBuffers);
+  }.bind(this);
 
   this._aclConnections = new Map();
 

--- a/test/lib/hci-socket/hci.test.js
+++ b/test/lib/hci-socket/hci.test.js
@@ -426,14 +426,14 @@ describe('hci-socket hci', () => {
     assert.calledOnceWithExactly(hci._socket.write, Buffer.from([0x01, 0x05, 0x14, 0x02, 0x34, 0x12]));
   });
 
-  it('should writeAclDataPkt - push in aclQueue and flushAcl', () => {
+  it('should writeAclDataPkt - push in aclQueue and flushAcl', async () => {
     hci.flushAcl = sinon.spy();
     hci._aclBuffers = [1, 2, 3, 4, 5, 6, 7, 8];
 
     const handle = 0x1234;
     const cid = 345;
     const data = Buffer.from([5, 6, 7, 8, 9, 10, 11]);
-    hci.writeAclDataPkt(handle, cid, data);
+    await hci.writeAclDataPkt(handle, cid, data);
 
     assert.calledOnceWithExactly(hci.flushAcl);
 
@@ -504,7 +504,7 @@ describe('hci-socket hci', () => {
       should(hci._aclQueue).deepEqual(queue);
     });
 
-    it('should write flush', () => {
+    it('should write flush', async () => {
       const queue = [
         {
           handle: 4660,
@@ -524,7 +524,7 @@ describe('hci-socket hci', () => {
       hci._aclConnections.set(4661, { pending: 2 });
       hci._aclBuffers = { num: 12 };
 
-      hci.flushAcl();
+      await hci.flushAcl();
 
       assert.callCount(hci._socket.write, 3);
       assert.calledWithExactly(hci._socket.write, Buffer.from([0x02, 0x34, 0x12, 0x08, 0x00, 0x07, 0x00, 0x59, 0x01, 0x05, 0x06, 0x07, 0x08]));


### PR DESCRIPTION
Fix for [Issue 246](https://github.com/abandonware/noble/issues/246)

As far as I can tell, the issue is caused by a race condition where _aclBuffers are not set when writeAclDataPkt is called. I made the modification shown in this pull request and tested them on my windows setup. The issue is fixed in my system but not thoroughly tested. I would appreciate some reviews from maintainers who understand the code base much better than I.

The main change was to add a promise in front of _aclBuffers that functions needing access to it could wait on before executing. This means that writeAclDataPkt and flushAcl where changed to async functions.