### PR TITLE
#271: Update npm-publish-action to latest version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 10.0.0
       - if: "contains(steps.log.outputs.message, 'Release ')"
-        uses: pascalgn/npm-publish-action@51fdb4531e99aac1873764ef7271af448dc42ab4
+        uses: pascalgn/npm-publish-action@1.3.9
         with: # All of theses inputs are optional
           tag_name: "v%s"
           tag_message: "v%s"


### PR DESCRIPTION
Hi!

I saw that that there's currently an issue going on with publishing the package to npm in #271. It seems that a recent git update now checks whether the folder into which a repo is cloned is owned by the same user running the 'git' executable for security purposes.

A fix has already been merged in npm-publish-action some while ago (see: https://github.com/pascalgn/npm-publish-action/issues/42). This PR would update the version of the plugin to the latest stable release.

With any luck, those should be the only changes needed.

Thanks for keeping noble alive! :)