### PR TITLE
Draft: #271: Update Windows image from 2016 to 2019

### DIFF
--- a/.github/workflows/nodepackage.yml
+++ b/.github/workflows/nodepackage.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-2016]
+        os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-2019]
         node: [12, 14]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -22,7 +22,7 @@ jobs:
           - name: linux
             os: ubuntu-latest
           - name: win32
-            os: windows-2016
+            os: windows-2019
     name: Build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The CI pipeline is still using the windows-2016 image which has been phased out by GitHub earlier this year (see: https://github.com/actions/runner-images/issues/4312). This causes no runners being available for picking up the win32 package/build steps, with them eventually timing out.

This initial PR bumps up the Windows image version used from 2016 to 2019.  If things fail, we should now at least get an error message telling what's wrong.

Please do not merge yet. Thanks!