### PR TITLE
fix gatt.js

### DIFF
--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -375,7 +375,7 @@ Gatt.prototype.discoverServices = function (uuids) {
       }
     }
 
-    if ((opcode !== ATT_OP_READ_BY_GROUP_RESP && opcode !== ATT_OP_ERROR) || services[services.length - 1].endHandle === 0xffff) {
+    if (opcode !== ATT_OP_READ_BY_GROUP_RESP || services[services.length - 1].endHandle === 0xffff) {
       const serviceUuids = [];
       for (i = 0; i < services.length; i++) {
         const uuid = services[i].uuid.trim();


### PR DESCRIPTION
partial revert of https://github.com/abandonware/noble/pull/249/files#diff-ad66052c5c812bc78c3b6aaca6043412e3cd622ba88352ca72ce9bc80385d7e5R363

which breaks discovering services of my lego bluetooth hub. The hub sends ATT_OP_READ_BY_GROUP_RESP twice and then ATT_OP_ERROR which lead to the discovery never finishing.