### PR TITLE
Revert the change for reseting service data on non scan hci events

### DIFF
--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -142,7 +142,7 @@ Gap.prototype.onHciLeAdvertisingReport = function (
     address,
     eir,
     previouslyDiscovered,
-    hasScanResponse
+    type
   );
 
   debug(`advertisement = ${JSON.stringify(advertisement, null, 0)}`);
@@ -211,7 +211,7 @@ Gap.prototype.onHciLeExtendedAdvertisingReport = function (
     address,
     eir,
     previouslyDiscovered,
-    hasScanResponse,
+    type,
     txpower
   );
 
@@ -258,7 +258,7 @@ Gap.prototype.parseServices = function (
   address,
   eir,
   previouslyDiscovered,
-  hasScanResponse,
+  leMetaEventType,
   txpower
 ) {
   let i = 0;
@@ -273,7 +273,7 @@ Gap.prototype.parseServices = function (
         solicitationServiceUuids: []
       };
 
-  if (!hasScanResponse) {
+  if (leMetaEventType !== LE_META_EVENT_TYPE_SCAN_RESPONSE) {
     // reset service data every non-scan response event
     advertisement.serviceData = [];
     advertisement.serviceUuids = [];


### PR DESCRIPTION
See the background discussion and logs what are happening here: https://github.com/abandonware/noble/issues/296

This commit https://github.com/abandonware/noble/commit/b67eea246f719947fc45b1b52b856e61637a8a8e changed the logic where the service data is reset  from the meta event type scan to ever having a scan response discovered, and so leading to ever growing serviceData arrays in advertisements. 

I reverted the logic to the one that was existing before this commit and introduced a test for catching the problem. I'm not so familiar with this codebase so this could use a another pair of eyes too 😅.