### PR TITLE
Update DiscoverPeripheralUUIDs to Use Object Map for Performance

### DIFF
--- a/lib/noble.js
+++ b/lib/noble.js
@@ -18,7 +18,7 @@ function Noble (bindings) {
   this._services = {};
   this._characteristics = {};
   this._descriptors = {};
-  this._discoveredPeripheralUUids = [];
+  this._discoveredPeripheralUUids = {};
 
   this._bindings.on('stateChange', this.onStateChange.bind(this));
   this._bindings.on('addressChange', this.onAddressChange.bind(this));
@@ -131,7 +131,7 @@ const startScanning = function (serviceUuids, allowDuplicates, callback) {
         });
       }
 
-      this._discoveredPeripheralUUids = [];
+      this._discoveredPeripheralUUids = {};
       this._allowDuplicates = allowDuplicates;
 
       this._bindings.startScanning(serviceUuids, allowDuplicates);
@@ -204,10 +204,10 @@ Noble.prototype.onDiscover = function (uuid, address, addressType, connectable, 
     peripheral.rssi = rssi;
   }
 
-  const previouslyDiscoverd = (this._discoveredPeripheralUUids.indexOf(uuid) !== -1);
+  const previouslyDiscoverd = this._discoveredPeripheralUUids[uuid] === true;
 
   if (!previouslyDiscoverd) {
-    this._discoveredPeripheralUUids.push(uuid);
+    this._discoveredPeripheralUUids[uuid] = true;
   }
 
   if (this._allowDuplicates || !previouslyDiscoverd || (!scannable && !connectable)) {

--- a/test/noble.test.js
+++ b/test/noble.test.js
@@ -563,7 +563,7 @@ describe('noble', () => {
       should(noble._services).have.keys(uuid);
       should(noble._characteristics).have.keys(uuid);
       should(noble._descriptors).have.keys(uuid);
-      should(noble._discoveredPeripheralUUids).deepEqual([uuid]);
+      should(noble._discoveredPeripheralUUids).deepEqual({ uuid: true });
 
       assert.calledOnceWithExactly(eventCallback, peripheral);
     });
@@ -613,7 +613,7 @@ describe('noble', () => {
       should(noble._services).be.empty();
       should(noble._characteristics).be.empty();
       should(noble._descriptors).be.empty();
-      should(noble._discoveredPeripheralUUids).deepEqual([uuid]);
+      should(noble._discoveredPeripheralUUids).deepEqual({ uuid: true });
 
       assert.calledOnceWithExactly(eventCallback, peripheral);
     });
@@ -627,7 +627,7 @@ describe('noble', () => {
       const rssi = 'rssi';
 
       // register peripheral
-      noble._discoveredPeripheralUUids = [uuid];
+      noble._discoveredPeripheralUUids = { uuid: true };
       noble._allowDuplicates = true;
 
       const eventCallback = sinon.spy();
@@ -654,7 +654,7 @@ describe('noble', () => {
       const rssi = 'rssi';
 
       // register peripheral
-      noble._discoveredPeripheralUUids = [uuid];
+      noble._discoveredPeripheralUUids = { uuid: true };
 
       const eventCallback = sinon.spy();
       noble.on('discover', eventCallback);


### PR DESCRIPTION
When running a continuous scan, the discoverPeripheralUUIDs continues to grow. Over time, this leads to slow lookup, as the existing implementation is required to perform an O(n) search through an array for each packet received.

To improve performance, we convert the array to an object map, allowing for O(1) lookup. This leads to a 98% performance improvement.

![image](https://user-images.githubusercontent.com/2492022/224512703-51e413ba-ee3d-433b-b37a-ad3aa2597747.png)
