### PR TITLE
Wrap Gap Debug in Conditional Check

### DIFF
--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -145,7 +145,9 @@ Gap.prototype.onHciLeAdvertisingReport = function (
     type
   );
 
-  debug(`advertisement = ${JSON.stringify(advertisement, null, 0)}`);
+  if (process.env.DEBUG === 'gap') {
+    debug(`advertisement = ${JSON.stringify(advertisement, null, 0)}`);
+  }
 
   const connectable =
     type === LE_META_EVENT_TYPE_SCAN_RESPONSE && previouslyDiscovered
@@ -215,7 +217,9 @@ Gap.prototype.onHciLeExtendedAdvertisingReport = function (
     txpower
   );
 
-  debug(`advertisement = ${JSON.stringify(advertisement, null, 0)}`);
+  if (process.env.DEBUG === 'gap') {
+    debug(`advertisement = ${JSON.stringify(advertisement, null, 0)}`);
+  }
 
   const connectable =
     type & 0x8 && previouslyDiscovered


### PR DESCRIPTION
To avoid JSON.stringify being called on each advertising packet, even when not in debug mode, wrap the function in a conditional to check if debugging is enabled.

