### PR TITLE
Fix undefined error

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -303,9 +303,7 @@ NobleBindings.prototype.onLeConnComplete = function (
       this.onConnectionParameterUpdateRequest.bind(this)
     );
 
-    setTimeout(() => {
-      this._gatts[handle].exchangeMtu();
-    }, 0);
+    this._gatts[handle].exchangeMtu();
   } else {
     uuid = this._pendingConnectionUuid;
     let statusMessage = Hci.STATUS_MAPPER[status] || 'HCI Error: Unknown';


### PR DESCRIPTION
This pull request removes the `setTimeout` call introduced in dd0518858a2db4daf4c268e024f9b1995e3aec7e, this can prevent `delete this._gatts[handle]` from being called first.

Fixes https://github.com/abandonware/noble/issues/303.