### PR TITLE
Fix MTU for peripheral

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,7 @@ export declare class Peripheral extends events.EventEmitter {
     connectable: boolean;
     advertisement: Advertisement;
     rssi: number;
+    mtu: number | null;
     services: Service[];
     state: 'error' | 'connecting' | 'connected' | 'disconnecting' | 'disconnected';
 

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -587,7 +587,7 @@ Noble.prototype.onHandleNotify = function (peripheralUuid, handle, data) {
 
 Noble.prototype.onMtu = function (peripheralUuid, mtu) {
   const peripheral = this._peripherals[peripheralUuid];
-  if (peripheral && peripheral.mtu && mtu) peripheral.mtu = mtu;
+  if (peripheral && mtu) peripheral.mtu = mtu;
 };
 
 module.exports = Noble;

--- a/test/noble.test.js
+++ b/test/noble.test.js
@@ -1508,25 +1508,26 @@ describe('noble', () => {
     });
   });
 
-  it('onMtu - should update peripheral mtu', () => {
+  it('onMtu - should update peripheral mtu when set before already', () => {
     const peripheral = {
-      mtu: 'nan'
+      mtu: 234
     };
 
     noble._peripherals = { uuid: peripheral };
-    noble.onMtu('uuid', 'mtu');
+    noble.onMtu('uuid', 123);
 
-    should(peripheral).deepEqual({ mtu: 'mtu' });
+    should(peripheral).deepEqual({ mtu: 123 });
   });
 
-  it('onMtu - should not update peripheral mtu', () => {
+  it('onMtu - should update peripheral mtu too when empty', () => {
     const peripheral = {
+      mtu: null
     };
 
     noble._peripherals = { uuid: peripheral };
-    noble.onMtu('uuid', 'mtu');
+    noble.onMtu('uuid', 123);
 
-    should(peripheral).deepEqual({ });
+    should(peripheral).deepEqual({ mtu: 123 });
   });
 
   describe('onIncludedServicesDiscover', () => {


### PR DESCRIPTION
The current version has two issues regarding MTU:
1.) Mising in types
2.) It is never set because the code only updates mtu if the peripheral.mtu is not falsy (what the default value null always is) so it was never updated.
I decided to remove this check. This could lead to the fact that the MTU could get updated after initially set which could be strange ... but would be the reality. Alternatively the code was just missing a "!" and wanted to only update mtu if "not aloready a value is set" ... no idea.