### PR TITLE
fix: catch error on `this._bindings.init()`

### DIFF
--- a/lib/noble.js
+++ b/lib/noble.js
@@ -58,7 +58,11 @@ function Noble (bindings) {
       this.initialized = true;
 
       process.nextTick(() => {
-        this._bindings.init();
+        try {
+          this._bindings.init();
+        } catch (error) {
+          this.emit('warning', 'Initialization of USB device failed: ' + error.message);
+        }
       });
     }
   });


### PR DESCRIPTION
### Current Situation

Using noble with developing Homebridge plugins. In situations where, for example, a user is running from a raspberry pi with no bluetooth, this leads to an error which cannot be caught and results in the node process crashing. I managed to recreate this by disabling the bluetooth on my pi by adding `dtoverlay=disable-bt` to my `/boot/config.txt` file.

Homebridge logs on plugin init:

```
/home/pi/govee/node_modules/@abandonware/noble/lib/hci-socket/hci.js:160
      this._socket.bindRaw(this._deviceId);
                   ^
Error: ENODEV, No such device
    at Hci.init (/home/pi/govee/node_modules/@abandonware/noble/lib/hci-socket/hci.js:160:20)
    at NobleBindings.init (/home/pi/govee/node_modules/@abandonware/noble/lib/hci-socket/bindings.js:100:13)
    at /home/pi/govee/node_modules/@abandonware/noble/lib/noble.js:61:24
    at processTicksAndRejections (node:internal/process/task_queues:77:11)
[27/07/2023, 08:07:33] [Govee] Child bridge process ended
[27/07/2023, 08:07:33] [Govee] Process Ended. Code: 1, Signal: null
[27/07/2023, 08:07:40] [Govee] Restarting Process...
```

With this PR fix, these logs become 

```
[27/07/2023, 08:13:05] [Govee] ***** No devices found to initialise. *****
[27/07/2023, 08:13:05] [Govee] [BLE] Initialisation of USB device failed: ENODEV, No such device.
```

Fixes https://github.com/abandonware/noble/issues/132