### PR TITLE
Update mac gyp binding to match setup guide recommendation

### DIFF
--- a/lib/mac/binding.gyp
+++ b/lib/mac/binding.gyp
@@ -7,7 +7,9 @@
       'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
+      'cflags+': ['-fvisibility=hidden'],
       'xcode_settings': {
+          'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
         'CLANG_CXX_LIBRARY': 'libc++',
         'MACOSX_DEPLOYMENT_TARGET': '10.7',


### PR DESCRIPTION
I ran into an issue using `noble` on Mac. 

If building an app using Xcode 15, running on older MacOS version (Big Sur and earlier) would cause a crash. 
Building and running the same code using Xcode 14 worked as expected.

After some investigation, I found some compiler flag recommendations in the `node-addon-api` setup docs that solve this issue:
https://github.com/nodejs/node-addon-api/blob/main/doc/setup.md#installation-and-usage

