### PR TITLE
Remove windows-build-tools in prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,6 @@ Make sure you have read and write permissions on the `/dev/usb/*` device that co
 
 [node-gyp requirements for Windows](https://github.com/TooTallNate/node-gyp#installation)
 
-Install the required tools and configurations using Microsoft's [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) from an elevated PowerShell or cmd.exe (run as Administrator).
-
-```cmd
-npm install --global --production windows-build-tools
-```
-
 [node-bluetooth-hci-socket prerequisites](#windows)
    * Compatible Bluetooth 5.0 Zephyr HCI-USB adapter (you need to add BLUETOOTH_HCI_SOCKET_USB_VID and BLUETOOTH_HCI_SOCKET_USB_PID to the process env)
    * Compatible Bluetooth 4.0 USB adapter


### PR DESCRIPTION
> [Windows-Build-Tools](https://github.com/felixrieseberg/windows-build-tools/tree/master?tab=readme-ov-file): The official Node.js for Windows installer can now automatically install the required tools.

And there is also a bug here: windows-build-tools can't be download in China. Because the Python download url in windows-build-tools is abandoned. The URL is https://npm.taobao.org/mirrors/python/2.7.15/python-2.7.15.amd64.msi. If you try it. You will see 404. And windows-build-tools has been archived by the owner on Sep 11, 2021. So we have to remove this description.